### PR TITLE
fix(types): update context params to be a Promise in handler functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ export const GET = createZodRoute()
   .params(paramsSchema)
   .query(querySchema)
   .body(bodySchema)
-  .handler((request, context) => {
-    const { id } = context.params;
+  .handler(async (request, context) => {
+    const { id } = await context.params; // Since Next.js 15 the params are now a promise
     const { search } = context.query;
     const { field } = context.body;
 
@@ -72,7 +72,7 @@ To define a route handler in Next.js:
 You can add middleware to your route handler with the `use` method.
 
 ```ts
-const safeRoute = createSafeRoute()
+const safeRoute = createZodRoute()
   .use(async (request, context) => {
     return { user: { id: 'user-123', role: 'admin' } };
   })
@@ -90,27 +90,37 @@ You can specify a custom error handler function with the `handleServerError` met
 
 To achieve this, define a custom error handler when creating the `safeRoute`:
 
+- Create a custom error class that extends `Error` and a `safeRoute` instance with a custom error handler:
+
 ```ts
-class CustomError extends Error {
-  constructor(message: string) {
+import { createZodRoute } from 'next-zod-route';
+import { NextResponse } from 'next/server';
+
+export class RouteError extends Error {
+  status?: number;
+  constructor(message: string, status?: number) {
     super(message);
-    this.name = 'CustomError';
+    this.name = 'RouteError';
+    this.message = message;
+    this.status = status || 400;
   }
 }
 
-const safeRoute = createSafeRoute({
+export const saferoute = createZodRoute({
   handleServerError: (error: Error) => {
-    if (error instanceof CustomError) {
-      return new Response(JSON.stringify({ message: error.name, details: error.message }), { status: 400 });
-    }
+    if (error instanceof RouteError) return NextResponse.json({ message: error.message }, { status: error.status });
 
-    return new Response(JSON.stringify({ message: 'Something went wrong' }), { status: 400 });
+    return NextResponse.json({ message: 'Something went wrong' }, { status: 400 });
   },
 });
+```
 
+- Use the `handleServerError` method to define a custom error handler.:
+
+```ts
 const GET = safeRoute.handler((request, context) => {
-  // This error will be handled by the custom error handler
-  throw new CustomError('Test error');
+  // This error will be handled by the custom error handler with a 500 status code
+  throw new RouteError('Test error', 500);
 });
 ```
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ import { Schema } from 'zod';
 
 export type HandlerFunction<TParams, TQuery, TBody, TContext> = (
   request: Request,
-  context: { params: TParams; query: TQuery; body: TBody; data: TContext },
+  context: { params: Promise<TParams>; query: TQuery; body: TBody; data: TContext },
 ) => any;
 
 export interface RouteHandlerBuilderConfig {
@@ -12,6 +12,6 @@ export interface RouteHandlerBuilderConfig {
   bodySchema: Schema;
 }
 
-export type OriginalRouteHandler = (request: Request, context?: { params: Promise<Record<string, unknown>> }) => any;
+export type OriginalRouteHandler = (request: Request, context: { params: Promise<Record<string, unknown>> }) => any;
 
 export type HandlerServerErrorFn = (error: Error) => Response;


### PR DESCRIPTION
### Related Issues:
- #3 

---

### Description:
This pull request includes changes to the `src/types.ts` file to improve type safety and consistency in the context parameter of handler functions. The most important changes include modifying the `HandlerFunction` and `OriginalRouteHandler` types to ensure that the `params` property is always a `Promise`.

Improvements to type safety and consistency:

* [`src/types.ts`](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aL6-R6): Updated the `HandlerFunction` type to ensure the `params` property in the `context` parameter is a `Promise`.
* [`src/types.ts`](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aL15-R15): Modified the `OriginalRouteHandler` type to ensure the `params` property in the `context` parameter is a `Promise`.