### PR TITLE
feat: Enhance type safety and response handling in route handlers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export { createZodRoute } from './createZodRoute';
-export { type HandlerFunction, type RouteHandlerBuilderConfig } from './types';
+export { type HandlerFunction, type RouteHandlerBuilderConfig, type RouteResponse } from './types';

--- a/src/routeHandlerBuilder.test.ts
+++ b/src/routeHandlerBuilder.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, expect, expectTypeOf, it } from 'vitest';
 import { z } from 'zod';
 
@@ -48,7 +49,7 @@ describe('params validation', () => {
 
     const request = new Request('http://localhost/');
     const response = await GET(request, { params: paramsToPromise({ id: 'invalid-uuid' }) });
-    const data = await response.json();
+    const data = (await response.json()) as any;
 
     expect(response.status).toBe(400);
     expect(data.message).toBe('Invalid params');
@@ -83,7 +84,7 @@ describe('query validation', () => {
 
     const request = new Request('http://localhost/?search=');
     const response = await GET(request, { params: Promise.resolve({}) });
-    const data = await response.json();
+    const data = (await response.json()) as any;
 
     expect(response.status).toBe(400);
     expect(data.message).toBe('Invalid query');
@@ -124,7 +125,7 @@ describe('body validation', () => {
       body: JSON.stringify({ field: 123 }),
     });
     const response = await POST(request, { params: Promise.resolve({}) });
-    const data = await response.json();
+    const data = (await response.json()) as any;
 
     expect(response.status).toBe(400);
     expect(data.message).toBe('Invalid body');
@@ -145,7 +146,7 @@ describe('body validation', () => {
     const response = await POST(request, { params: Promise.resolve({}) });
 
     expect(response.status).toBe(400); // Should fail with 400 since body is required but not provided
-    const data = await response.json();
+    const data = (await response.json()) as any;
     expect(data.message).toBe('Invalid body');
   });
 
@@ -162,7 +163,7 @@ describe('body validation', () => {
     const response = await POST(request, { params: Promise.resolve({}) });
 
     expect(response.status).toBe(200); // Should fail with 400 since body is required but not provided
-    const data = await response.json();
+    const data = (await response.json()) as any;
     expect(data.success).toBe(true);
   });
 });
@@ -216,7 +217,7 @@ describe('combined validation', () => {
     });
 
     const response = await POST(request, { params: paramsToPromise({ id: 'invalid-uuid' }) });
-    const data = await response.json();
+    const data = (await response.json()) as any;
 
     expect(response.status).toBe(400);
     expect(data.message).toBe('Invalid params');
@@ -241,7 +242,7 @@ describe('combined validation', () => {
     });
 
     const response = await POST(request, { params: paramsToPromise({ id: '550e8400-e29b-41d4-a716-446655440000' }) });
-    const data = await response.json();
+    const data = (await response.json()) as any;
 
     expect(response.status).toBe(400);
     expect(data.message).toBe('Invalid query');
@@ -266,7 +267,7 @@ describe('combined validation', () => {
     });
 
     const response = await POST(request, { params: paramsToPromise({ id: '550e8400-e29b-41d4-a716-446655440000' }) });
-    const data = await response.json();
+    const data = (await response.json()) as any;
 
     expect(response.status).toBe(400);
     expect(data.message).toBe('Invalid body');
@@ -420,7 +421,7 @@ describe('form data handling', () => {
     });
 
     const response = await POST(request, { params: Promise.resolve({}) });
-    const data = await response.json();
+    const data = (await response.json()) as any;
 
     expect(response.status).toBe(200);
     expect(data).toEqual({ field: '' });
@@ -543,7 +544,7 @@ describe('metadata validation', () => {
     const response = await GET(request, {
       params: Promise.resolve({}),
     });
-    const data = await response.json();
+    const data = (await response.json()) as any;
 
     expect(response.status).toBe(400);
     expect(data.message).toBe('Invalid metadata');
@@ -978,5 +979,28 @@ describe('permission checking with metadata', () => {
       authorized: true,
       logged: true,
     });
+  });
+});
+
+describe('handler return type', () => {
+  it('should ensure handler returns a Response type', () => {
+    const GET = createZodRoute().handler(() => {
+      return Response.json({ success: true }, { status: 200 });
+    });
+
+    // This test verifies at compile time that the handler returns a Response
+    expectTypeOf(GET).toMatchTypeOf<
+      (request: Request, context: { params: Promise<Record<string, unknown>> }) => Promise<Response>
+    >();
+  });
+
+  it('should allow handler to return a Promise<Response>', () => {
+    const GET = createZodRoute().handler(async () => {
+      return Promise.resolve(Response.json({ success: true }, { status: 200 }));
+    });
+
+    expectTypeOf(GET).toMatchTypeOf<
+      (request: Request, context: { params: Promise<Record<string, unknown>> }) => Promise<Response>
+    >();
   });
 });

--- a/src/routeHandlerBuilder.ts
+++ b/src/routeHandlerBuilder.ts
@@ -155,9 +155,9 @@ export class RouteHandlerBuilder<
    * @param handler - The handler function that will be called when the route is hit
    * @returns The original route handler that Next.js expects with the validation logic
    */
-  handler(
-    handler: HandlerFunction<z.infer<TParams>, z.infer<TQuery>, z.infer<TBody>, TContext, z.infer<TMetadata>>,
-  ): OriginalRouteHandler {
+  handler<TReturn = Response>(
+    handler: HandlerFunction<z.infer<TParams>, z.infer<TQuery>, z.infer<TBody>, TContext, z.infer<TMetadata>, TReturn>,
+  ): OriginalRouteHandler<Promise<Response>> {
     return async (request, context): Promise<Response> => {
       try {
         const url = new URL(request.url);

--- a/src/routeHandlerBuilder.ts
+++ b/src/routeHandlerBuilder.ts
@@ -31,6 +31,7 @@ export class RouteHandlerBuilder<
   // eslint-disable-next-line @typescript-eslint/ban-types
   TContext = {},
   TMetadata extends z.Schema = z.Schema,
+  TResponse extends z.Schema = z.Schema,
 > {
   readonly config: {
     paramsSchema: TParams;
@@ -49,6 +50,7 @@ export class RouteHandlerBuilder<
       querySchema: undefined as unknown as TQuery,
       bodySchema: undefined as unknown as TBody,
       metadataSchema: undefined as unknown as TMetadata,
+      responseSchema: undefined as unknown as TResponse,
     },
     middlewares = [],
     handleServerError,
@@ -60,11 +62,13 @@ export class RouteHandlerBuilder<
       querySchema: TQuery;
       bodySchema: TBody;
       metadataSchema?: TMetadata;
+      responseSchema?: TResponse;
     };
     middlewares?: Array<MiddlewareFunction<TContext, Record<string, unknown>, z.infer<TMetadata>>>;
     handleServerError?: HandlerServerErrorFn;
     contextType: TContext;
     metadataValue?: z.infer<TMetadata>;
+    responseSchema?: TResponse;
   }) {
     this.config = config;
     this.middlewares = middlewares;
@@ -106,6 +110,18 @@ export class RouteHandlerBuilder<
     return new RouteHandlerBuilder<TParams, TQuery, T, TContext, TMetadata>({
       ...this,
       config: { ...this.config, bodySchema: schema },
+    });
+  }
+
+  /**
+   * Define the schema for the response
+   * @param schema - The schema for the response
+   * @returns A new instance of the RouteHandlerBuilder
+   */
+  response<T extends z.Schema>(schema: T) {
+    return new RouteHandlerBuilder<TParams, TQuery, TBody, TContext, TMetadata, T>({
+      ...this,
+      config: { ...this.config, responseSchema: schema },
     });
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -92,3 +92,5 @@ export type HandlerServerErrorFn = (error: Error) => Response;
  * Utility type to extract the return type of a route handler
  */
 export type RouteResponse<T> = T extends OriginalRouteHandler<infer R> ? Awaited<R> : never;
+
+export type ZodRouteResponse<T> = Response & { json: () => Promise<T> };

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,10 +9,10 @@ import { Schema } from 'zod';
  * @param context - The context object
  * @returns The response from the route handler
  */
-export type HandlerFunction<TParams, TQuery, TBody, TContext, TMetadata = unknown> = (
+export type HandlerFunction<TParams, TQuery, TBody, TContext, TMetadata = unknown, TReturn = any> = (
   request: Request,
   context: { params: TParams; query: TQuery; body: TBody; ctx: TContext; metadata?: TMetadata },
-) => any;
+) => TReturn;
 
 /**
  * Represents the merged context type between the existing context and new context added by middleware
@@ -76,7 +76,10 @@ export interface RouteHandlerBuilderConfig {
  * Original Next.js route handler type for reference
  * This is the type that Next.js uses internally before our library wraps it
  */
-export type OriginalRouteHandler = (request: Request, context: { params: Promise<Record<string, unknown>> }) => any;
+export type OriginalRouteHandler<TReturn = any> = (
+  request: Request,
+  context: { params: Promise<Record<string, unknown>> },
+) => TReturn;
 
 /**
  * Function that handles server errors in route handlers
@@ -84,3 +87,8 @@ export type OriginalRouteHandler = (request: Request, context: { params: Promise
  * @returns Response object with appropriate error details and status code
  */
 export type HandlerServerErrorFn = (error: Error) => Response;
+
+/**
+ * Utility type to extract the return type of a route handler
+ */
+export type RouteResponse<T> = T extends OriginalRouteHandler<infer R> ? Awaited<R> : never;


### PR DESCRIPTION
- Added `RouteResponse` type to improve return type inference for route handlers.
- Updated `HandlerFunction` and `OriginalRouteHandler` types to support generic return types.
- Modified tests to cast response data to `any` for better type handling during validation checks.
- Included a new test suite to ensure handler return types are correctly inferred as `Response`.

Close #10 