### PR TITLE
docs: Fix timing calculation example in loggingMiddleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,8 +225,8 @@ const loggingMiddleware = async ({ next }) => {
 
   const response = await next();
 
-  const endTime = performance.now() - start;
-  console.log(`After handler - took ${Math.round(endTime - startTime)}ms`);
+  const endTime = performance.now() - startTime;
+  console.log(`After handler - took ${Math.round(endTime)}ms`);
 
   return response;
 };


### PR DESCRIPTION
**Fixes #** _(Add the issue number if applicable, otherwise remove this line)_  

## **Proposed Changes**  
- Fixes the timing calculation in the `loggingMiddleware` example.  
- Replaces `performance.now() - start` with `performance.now() - startTime` to avoid using an undefined variable.  
- Ensures the example code is correct and runs without errors.  

### **Why is this needed?**  
The example contained an error where `start` was used without being defined, which could cause an exception when executing the middleware.