### PR TITLE
4. Feature/strict mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A fork from [next-safe-route](https://github.com/richardsolomou/next-safe-route)
 - **🧪 Fully Tested:** Extensive test suite to ensure everything works reliably.
 - **🔐 Enhanced Middleware System:** Powerful middleware system with pre/post handler execution, response modification, and context chaining.
 - **🎯 Metadata Support:** Add and validate metadata for your routes with full type safety.
-- **🛡️ Custom Error Handling:** Flexible error handling with custom error handlers for both middleware and route handlers.
+- **🛡️ Custom Error Handling:** Flexible error handling with custom error handlers for both middleware and route handlers, plus customizable Zod validation error responses.
 
 ## Installation
 
@@ -212,9 +212,10 @@ export const GET = createZodRoute()
 
 ### Error Handling
 
-When response validation fails, a 500 error is returned:
+When response validation fails, you can customize the error handling using `handleZodError`. If no `handleZodError` is provided, it defaults to a 500 error:
 
 ```ts
+// Default behavior (500 error)
 export const GET = createZodRoute()
   .response(200, z.object({ success: z.boolean(), data: z.string() }))
   .handler(() => {
@@ -228,6 +229,31 @@ export const GET = createZodRoute()
 //   "message": "Invalid response: response body does not match schema for status 200",
 //   "errors": [...]
 // }
+
+// Custom error handling
+import { ZodError } from 'zod';
+
+const handleZodError = (field: string, error: ZodError) => {
+  if (field === 'response') {
+    // Handle response validation errors differently
+    return new Response(
+      JSON.stringify({
+        code: 'RESPONSE_VALIDATION_ERROR',
+        message: 'Response does not match expected schema',
+        errors: error.issues,
+      }),
+      { status: 422 },
+    );
+  }
+  // Handle other validation errors
+  return new Response(JSON.stringify({ field, errors: error.issues }), { status: 400 });
+};
+
+export const GET = createZodRoute({ handleZodError })
+  .response(200, z.object({ success: z.boolean(), data: z.string() }))
+  .handler(() => {
+    return Response.json({ success: true }, { status: 200 });
+  });
 ```
 
 ## Advanced Usage
@@ -610,13 +636,86 @@ export const GET = safeRoute
 
 By default, if no custom error handler is provided, the library will return a generic "Internal server error" message with a 500 status code to avoid information leakage.
 
+### Custom Zod Validation Error Handling
+
+You can customize how Zod validation errors (params, query, body, headers, metadata, response) are formatted by providing a `handleZodError` callback:
+
+```ts
+import { createZodRoute } from 'next-zod-route';
+import { z, ZodError } from 'zod';
+
+const handleZodError = (
+  field: 'params' | 'query' | 'body' | 'headers' | 'metadata' | 'response',
+  error: ZodError,
+) => {
+  // Customize the error response structure
+  return new Response(
+    JSON.stringify({
+      code: 'VALIDATION_ERROR',
+      field,
+      message: `Validation failed for ${field}`,
+      errors: error.issues.map((issue) => ({
+        message: issue.message,
+        path: issue.path.join('.'),
+        code: issue.code,
+      })),
+    }),
+    { status: 422 }, // Use 422 Unprocessable Entity for validation errors
+  );
+};
+
+const safeRoute = createZodRoute({
+  handleZodError,
+});
+
+export const POST = safeRoute
+  .body(z.object({ email: z.string().email(), name: z.string().min(1) }))
+  .handler((request, context) => {
+    return Response.json({ success: true });
+  });
+```
+
+The `handleZodError` function receives:
+- `field`: The type of field that failed validation ('params', 'query', 'body', 'headers', 'metadata', or 'response')
+- `error`: A `ZodError` instance containing all validation error details (accessible via `error.issues`)
+
+**Note:** `handleZodError` handles all Zod validation errors including request data (params, query, body, headers, metadata) and response validation. If `handleZodError` is not provided, response validation errors default to 500 status codes, while request validation errors default to 400.
+
+### Using Both Error Handlers
+
+You can use both `handleServerError` and `handleZodError` together:
+
+```ts
+const safeRoute = createZodRoute({
+  handleServerError: (error: Error) => {
+    // Handle unexpected server errors
+    return new Response(JSON.stringify({ message: 'Internal server error' }), { status: 500 });
+  },
+  handleZodError: (field, error) => {
+    // Handle validation errors with custom format
+    return new Response(
+      JSON.stringify({
+        error: 'Validation failed',
+        field,
+        details: error.issues,
+      }),
+      { status: 400 },
+    );
+  },
+});
+```
+
 ## Validation Errors
 
-When validation fails, the library returns appropriate error responses:
+When validation fails, the library returns appropriate error responses by default:
 
-- Invalid params: `{ message: 'Invalid params' }` with status 400
-- Invalid query: `{ message: 'Invalid query' }` with status 400
-- Invalid body: `{ message: 'Invalid body' }` with status 400
+- Invalid params: `{ message: 'Invalid params', errors: [...] }` with status 400
+- Invalid query: `{ message: 'Invalid query', errors: [...] }` with status 400
+- Invalid body: `{ message: 'Invalid body', errors: [...] }` with status 400
+- Invalid headers: `{ message: 'Invalid headers', errors: [...] }` with status 400
+- Invalid metadata: `{ message: 'Invalid metadata', errors: [...] }` with status 400
+
+You can customize these error responses using the `handleZodError` callback (see above).
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A fork from [next-safe-route](https://github.com/richardsolomou/next-safe-route)
 ## Features
 
 - **✅ Schema Validation:** Automatically validates request parameters, query strings, and body content with built-in error handling.
+- **📤 Response Validation:** Validate response bodies against Zod schemas based on HTTP status codes to ensure API contract compliance.
 - **🧷 Type-Safe:** Works with full TypeScript type safety for parameters, query strings, and body content.
 - **😌 Easy to Use:** Simple and intuitive API that makes defining route handlers a breeze.
 - **🔄 Flexible Response Handling:** Return Response objects directly or return plain objects that are automatically converted to JSON responses.
@@ -112,6 +113,121 @@ return NextResponse.json({ data: 'value' }, { status: 200 });
 
 ```ts
 return { data: 'value' };
+```
+
+## Response Validation
+
+`next-zod-route` allows you to validate response bodies against Zod schemas based on HTTP status codes. This ensures that your API responses match the expected structure.
+
+### Basic Usage
+
+```ts
+import { createZodRoute } from 'next-zod-route';
+import { z } from 'zod';
+
+const successSchema = z.object({
+  success: z.boolean(),
+  data: z.string(),
+});
+
+const errorSchema = z.object({
+  error: z.string(),
+  message: z.string(),
+});
+
+export const GET = createZodRoute()
+  .response(200, successSchema)
+  .response(400, errorSchema)
+  .handler((request, context) => {
+    // This response will be validated against successSchema
+    return Response.json({ success: true, data: 'Hello World' }, { status: 200 });
+  });
+```
+
+### How It Works
+
+- The `response()` method can be called multiple times to register schemas for different status codes
+- After the handler completes, the response body is validated against the schema matching the response's status code
+- If no schema is registered for a status code, validation is skipped
+- If validation fails, a 500 error is returned with validation details
+- Only JSON responses are validated (non-JSON responses are skipped)
+
+### Validation Behavior
+
+- **Successful validation**: The response is returned as-is
+- **Validation failure**: Returns a 500 error with validation error details
+- **No schema registered**: Validation is skipped, response is returned normally
+- **Non-JSON responses**: Validation is skipped (e.g., text/plain, image/\*)
+- **Plain object returns**: Automatically converted to a 200 response and validated against the 200 schema if registered
+
+### Multiple Status Codes
+
+You can register schemas for multiple status codes:
+
+```ts
+export const POST = createZodRoute()
+  .response(201, z.object({ id: z.string(), created: z.boolean() }))
+  .response(400, z.object({ error: z.string() }))
+  .response(404, z.object({ error: z.string(), code: z.literal('NOT_FOUND') }))
+  .handler((request, context) => {
+    // Response will be validated based on the status code returned
+    return Response.json({ id: '123', created: true }, { status: 201 });
+  });
+```
+
+### Duplicate Status Codes
+
+Registering the same status code twice is not allowed and will throw an error at runtime:
+
+```ts
+const route = createZodRoute().response(200, schema1);
+
+// This will throw an error
+route.response(200, schema2); // Error: Response schema for status code 200 has already been registered
+```
+
+### Combined with Request Validation
+
+Response validation works seamlessly with request validation:
+
+```ts
+const paramsSchema = z.object({
+  id: z.string(),
+});
+
+const responseSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+});
+
+export const GET = createZodRoute()
+  .params(paramsSchema)
+  .response(200, responseSchema)
+  .handler((request, context) => {
+    const { id } = context.params;
+    // Both request params and response are validated
+    return Response.json({ id, name: 'John Doe' }, { status: 200 });
+  });
+```
+
+### Error Handling
+
+When response validation fails, a 500 error is returned:
+
+```ts
+export const GET = createZodRoute()
+  .response(200, z.object({ success: z.boolean(), data: z.string() }))
+  .handler(() => {
+    // Missing required 'data' field - will return 500
+    return Response.json({ success: true }, { status: 200 });
+  });
+
+// Response will be:
+// Status: 500
+// Body: {
+//   "message": "Invalid response: response body does not match schema for status 200",
+//   "errors": [...]
+// }
 ```
 
 ## Advanced Usage

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A fork from [next-safe-route](https://github.com/richardsolomou/next-safe-route)
 
 - **✅ Schema Validation:** Automatically validates request parameters, query strings, and body content with built-in error handling.
 - **📤 Response Validation:** Validate response bodies against Zod schemas based on HTTP status codes to ensure API contract compliance.
+- **🔒 Strict Mode:** Optional strict mode that strips unknown properties from both requests and responses, ensures API contract compliance, and prevents data leakage.
 - **🧷 Type-Safe:** Works with full TypeScript type safety for parameters, query strings, and body content.
 - **😌 Easy to Use:** Simple and intuitive API that makes defining route handlers a breeze.
 - **🔄 Flexible Response Handling:** Return Response objects directly or return plain objects that are automatically converted to JSON responses.
@@ -255,6 +256,242 @@ export const GET = createZodRoute({ handleZodError })
     return Response.json({ success: true }, { status: 200 });
   });
 ```
+
+## Strict Mode
+
+Strict mode enforces stricter validation rules for both request and response data. When enabled, it:
+
+1. **Strips unknown properties** from validated data (using Zod's `strip()`)
+2. **Ignores request data** (params, query, body) when no schema is defined
+3. **Requires response validators** for all JSON responses
+4. **Strips unknown properties** from response bodies before returning them
+
+### Enabling Strict Mode
+
+Enable strict mode by passing `strict: true` when creating a route:
+
+```ts
+export const GET = createZodRoute({ strict: true })
+  .params(z.object({ id: z.string() }))
+  .response(200, z.object({ success: z.boolean() }))
+  .handler((request, context) => {
+    return Response.json({ success: true }, { status: 200 });
+  });
+```
+
+### Request Validation in Strict Mode
+
+#### Stripping Unknown Properties
+
+In strict mode, unknown properties are automatically stripped from validated request data:
+
+```ts
+const paramsSchema = z.object({
+  id: z.string(),
+});
+
+export const GET = createZodRoute({ strict: true })
+  .params(paramsSchema)
+  .handler((request, context) => {
+    // Even if request includes { id: '123', extra: 'data' },
+    // context.params will only contain { id: '123' }
+    const { id } = context.params;
+    // extra property is stripped
+    return Response.json({ id });
+  });
+```
+
+#### Ignoring Data Without Schemas
+
+In strict mode, if no schema is defined for params, query, or body, that data is ignored (set to empty object):
+
+```ts
+export const GET = createZodRoute({ strict: true }).handler((request, context) => {
+  // Even if params include { id: '123', extra: 'data' },
+  // context.params will be {}
+  expect(context.params).toEqual({});
+  expect(context.query).toEqual({});
+  expect(context.body).toEqual({});
+  return Response.json({ success: true });
+});
+```
+
+This ensures that only explicitly defined and validated data is available in your handler.
+
+### Response Validation in Strict Mode
+
+#### Stripping Unknown Properties from Responses
+
+In strict mode, unknown properties are stripped from response bodies before returning them:
+
+```ts
+const responseSchema = z.object({
+  success: z.literal(true),
+  error: z.literal(false),
+  data: z.object({
+    message: z.string(),
+  }),
+});
+
+export const GET = createZodRoute({ strict: true })
+  .response(200, responseSchema)
+  .handler(() => {
+    return Response.json(
+      {
+        success: true,
+        error: false,
+        data: {
+          id: 123, // This will be stripped - not in schema
+          message: 'Hello World',
+        },
+      },
+      { status: 200 },
+    );
+  });
+
+// Response will only contain:
+// {
+//   "success": true,
+//   "error": false,
+//   "data": {
+//     "message": "Hello World"
+//   }
+// }
+```
+
+This works for nested objects at any depth:
+
+```ts
+const responseSchema = z.object({
+  success: z.boolean(),
+  data: z.object({
+    user: z.object({
+      name: z.string(),
+      profile: z.object({
+        email: z.string(),
+      }),
+    }),
+  }),
+});
+
+export const GET = createZodRoute({ strict: true })
+  .response(200, responseSchema)
+  .handler(() => {
+    return Response.json(
+      {
+        success: true,
+        data: {
+          id: 123, // Stripped
+          user: {
+            id: 456, // Stripped
+            name: 'John',
+            age: 30, // Stripped
+            profile: {
+              id: 789, // Stripped
+              email: 'john@example.com',
+              phone: '123-456-7890', // Stripped
+            },
+          },
+        },
+      },
+      { status: 200 },
+    );
+  });
+
+// Response will only contain schema-defined properties:
+// {
+//   "success": true,
+//   "data": {
+//     "user": {
+//       "name": "John",
+//       "profile": {
+//         "email": "john@example.com"
+//       }
+//     }
+//   }
+// }
+```
+
+#### Requiring Response Validators
+
+In strict mode, all JSON responses must have a registered validator. If a JSON response is returned without a validator, a 500 error is returned:
+
+```ts
+export const GET = createZodRoute({ strict: true }).handler(() => {
+  // This will return a 500 error because no validator is registered for 200
+  return Response.json({ success: true }, { status: 200 });
+});
+
+// Response:
+// Status: 500
+// Body: {
+//   "message": "Invalid response: response validator required for status code 200 in strict mode"
+// }
+```
+
+Non-JSON responses (like `text/plain` or images) are exempt from this requirement:
+
+```ts
+export const GET = createZodRoute({ strict: true }).handler(() => {
+  // This is allowed - non-JSON responses don't need validators
+  return new Response('plain text', {
+    status: 200,
+    headers: { 'Content-Type': 'text/plain' },
+  });
+});
+```
+
+### Complete Example
+
+Here's a complete example showing strict mode in action:
+
+```ts
+const paramsSchema = z.object({
+  id: z.string().uuid(),
+});
+
+const querySchema = z.object({
+  search: z.string(),
+});
+
+const responseSchema = z.object({
+  id: z.string(),
+  search: z.string(),
+  message: z.string(),
+});
+
+export const GET = createZodRoute({ strict: true })
+  .params(paramsSchema)
+  .query(querySchema)
+  .response(200, responseSchema)
+  .handler((request, context) => {
+    const { id } = context.params;
+    const { search } = context.query;
+
+    // Extra properties in response will be stripped
+    return Response.json(
+      {
+        id,
+        search,
+        message: 'Hello World',
+        extra: 'will-be-stripped', // Stripped - not in schema
+        timestamp: Date.now(), // Stripped - not in schema
+      },
+      { status: 200 },
+    );
+  });
+```
+
+### When to Use Strict Mode
+
+Use strict mode when:
+
+- **API Contract Compliance**: You want to ensure responses match exactly what's documented in your API contract
+- **Data Security**: You want to prevent accidentally leaking sensitive data through extra properties
+- **Type Safety**: You want maximum type safety and want to catch issues at runtime
+- **API Versioning**: You want strict control over what data is sent/received for API versioning
+
+**Note:** Strict mode is opt-in and defaults to `false` for backward compatibility.
 
 ## Advanced Usage
 
@@ -642,12 +879,9 @@ You can customize how Zod validation errors (params, query, body, headers, metad
 
 ```ts
 import { createZodRoute } from 'next-zod-route';
-import { z, ZodError } from 'zod';
+import { ZodError, z } from 'zod';
 
-const handleZodError = (
-  field: 'params' | 'query' | 'body' | 'headers' | 'metadata' | 'response',
-  error: ZodError,
-) => {
+const handleZodError = (field: 'params' | 'query' | 'body' | 'headers' | 'metadata' | 'response', error: ZodError) => {
   // Customize the error response structure
   return new Response(
     JSON.stringify({
@@ -676,6 +910,7 @@ export const POST = safeRoute
 ```
 
 The `handleZodError` function receives:
+
 - `field`: The type of field that failed validation ('params', 'query', 'body', 'headers', 'metadata', or 'response')
 - `error`: A `ZodError` instance containing all validation error details (accessible via `error.issues`)
 

--- a/src/createZodRoute.ts
+++ b/src/createZodRoute.ts
@@ -1,9 +1,13 @@
 import { RouteHandlerBuilder } from './routeHandlerBuilder';
-import { HandlerServerErrorFn } from './types';
+import { HandlerServerErrorFn, HandlerZodErrorFn } from './types';
 
-export function createZodRoute(params?: { handleServerError?: HandlerServerErrorFn }) {
+export function createZodRoute(params?: {
+  handleServerError?: HandlerServerErrorFn;
+  handleZodError?: HandlerZodErrorFn;
+}) {
   return new RouteHandlerBuilder({
     handleServerError: params?.handleServerError,
+    handleZodError: params?.handleZodError,
     contextType: {},
   });
 }

--- a/src/createZodRoute.ts
+++ b/src/createZodRoute.ts
@@ -1,9 +1,10 @@
 import { RouteHandlerBuilder } from './routeHandlerBuilder';
 import { HandlerServerErrorFn } from './types';
 
-export function createZodRoute(params?: { handleServerError?: HandlerServerErrorFn }) {
+export function createZodRoute(params?: { handleServerError?: HandlerServerErrorFn; strict?: boolean }) {
   return new RouteHandlerBuilder({
     handleServerError: params?.handleServerError,
+    strict: params?.strict ?? false,
     contextType: {},
   });
 }

--- a/src/routeHandlerBuilder.test.ts
+++ b/src/routeHandlerBuilder.test.ts
@@ -1000,3 +1000,235 @@ describe('permission checking with metadata', () => {
     });
   });
 });
+
+describe('response validation', () => {
+  const successResponseSchema = z.object({
+    success: z.boolean(),
+    data: z.string(),
+  });
+
+  const errorResponseSchema = z.object({
+    error: z.string(),
+    message: z.string(),
+  });
+
+  it('should validate response body against schema for matching status code', async () => {
+    const GET = createZodRoute()
+      .response(200, successResponseSchema)
+      .handler(() => {
+        return Response.json({ success: true, data: 'test' }, { status: 200 });
+      });
+
+    const request = new Request('http://localhost/');
+    const response = await GET(request, { params: Promise.resolve({}) });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({ success: true, data: 'test' });
+  });
+
+  it('should return 500 error when response body does not match schema', async () => {
+    const GET = createZodRoute()
+      .response(200, successResponseSchema)
+      .handler(() => {
+        // Return invalid response (missing required fields)
+        return Response.json({ success: true }, { status: 200 });
+      });
+
+    const request = new Request('http://localhost/');
+    const response = await GET(request, { params: Promise.resolve({}) });
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.message).toContain('Invalid response');
+    expect(data.errors).toBeDefined();
+  });
+
+  it('should validate multiple status codes with different schemas', async () => {
+    const GET = createZodRoute()
+      .response(200, successResponseSchema)
+      .response(400, errorResponseSchema)
+      .handler(() => {
+        return Response.json({ success: true, data: 'test' }, { status: 200 });
+      });
+
+    const request = new Request('http://localhost/');
+    const response = await GET(request, { params: Promise.resolve({}) });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({ success: true, data: 'test' });
+  });
+
+  it('should skip validation when no schema is registered for status code', async () => {
+    const GET = createZodRoute()
+      .response(200, successResponseSchema)
+      .handler(() => {
+        // Return 404 without schema - should not validate
+        return Response.json({ notValidated: true }, { status: 404 });
+      });
+
+    const request = new Request('http://localhost/');
+    const response = await GET(request, { params: Promise.resolve({}) });
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data).toEqual({ notValidated: true });
+  });
+
+  it('should validate plain object returns against 200 schema', async () => {
+    const GET = createZodRoute()
+      .response(200, successResponseSchema)
+      .handler(() => {
+        // Return plain object (will be converted to 200 response)
+        return { success: true, data: 'test' };
+      });
+
+    const request = new Request('http://localhost/');
+    const response = await GET(request, { params: Promise.resolve({}) });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({ success: true, data: 'test' });
+  });
+
+  it('should return 500 error when plain object does not match 200 schema', async () => {
+    const GET = createZodRoute()
+      .response(200, successResponseSchema)
+      .handler(() => {
+        // Return invalid plain object
+        return { invalid: 'data' };
+      });
+
+    const request = new Request('http://localhost/');
+    const response = await GET(request, { params: Promise.resolve({}) });
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.message).toContain('Invalid response');
+  });
+
+  it('should skip validation for non-JSON responses', async () => {
+    const GET = createZodRoute()
+      .response(200, successResponseSchema)
+      .handler(() => {
+        // Return text response
+        return new Response('plain text', {
+          status: 200,
+          headers: { 'Content-Type': 'text/plain' },
+        });
+      });
+
+    const request = new Request('http://localhost/');
+    const response = await GET(request, { params: Promise.resolve({}) });
+    const text = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(text).toBe('plain text');
+  });
+
+  it('should return 500 error when response body is not valid JSON', async () => {
+    const GET = createZodRoute()
+      .response(200, successResponseSchema)
+      .handler(() => {
+        // Return invalid JSON
+        return new Response('invalid json {', {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      });
+
+    const request = new Request('http://localhost/');
+    const response = await GET(request, { params: Promise.resolve({}) });
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.message).toContain('Invalid response');
+  });
+
+  it('should validate middleware responses', async () => {
+    const middleware: MiddlewareFunction = async ({ next }) => {
+      const response = await next();
+      // Middleware returns a response that should be validated
+      return Response.json({ success: true, data: 'middleware' }, { status: 200 });
+    };
+
+    const GET = createZodRoute()
+      .response(200, successResponseSchema)
+      .use(middleware)
+      .handler(() => {
+        return { test: 'data' };
+      });
+
+    const request = new Request('http://localhost/');
+    const response = await GET(request, { params: Promise.resolve({}) });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({ success: true, data: 'middleware' });
+  });
+
+  it('should throw error when trying to register duplicate status code', () => {
+    const route = createZodRoute().response(200, successResponseSchema);
+
+    expect(() => {
+      route.response(200, errorResponseSchema);
+    }).toThrow('Response schema for status code 200 has already been registered');
+  });
+
+  it('should work with combined request and response validation', async () => {
+    const GET = createZodRoute()
+      .params(paramsSchema)
+      .query(querySchema)
+      .response(200, successResponseSchema)
+      .handler((request, context) => {
+        const { id } = context.params;
+        const { search } = context.query;
+        return Response.json({ success: true, data: `${id}-${search}` }, { status: 200 });
+      });
+
+    const request = new Request('http://localhost/?search=test');
+    const response = await GET(request, {
+      params: paramsToPromise({ id: '550e8400-e29b-41d4-a716-446655440000' }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({
+      success: true,
+      data: '550e8400-e29b-41d4-a716-446655440000-test',
+    });
+  });
+
+  it('should validate different status codes correctly', async () => {
+    const POST = createZodRoute()
+      .response(201, z.object({ id: z.string(), created: z.boolean() }))
+      .response(400, errorResponseSchema)
+      .handler(() => {
+        return Response.json({ id: '123', created: true }, { status: 201 });
+      });
+
+    const request = new Request('http://localhost/', { method: 'POST' });
+    const response = await POST(request, { params: Promise.resolve({}) });
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(data).toEqual({ id: '123', created: true });
+  });
+
+  it('should return 500 when response for 201 does not match schema', async () => {
+    const POST = createZodRoute()
+      .response(201, z.object({ id: z.string(), created: z.boolean() }))
+      .handler(() => {
+        // Missing required 'created' field
+        return Response.json({ id: '123' }, { status: 201 });
+      });
+
+    const request = new Request('http://localhost/', { method: 'POST' });
+    const response = await POST(request, { params: Promise.resolve({}) });
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.message).toContain('Invalid response');
+  });
+});

--- a/src/routeHandlerBuilder.test.ts
+++ b/src/routeHandlerBuilder.test.ts
@@ -1232,3 +1232,362 @@ describe('response validation', () => {
     expect(data.message).toContain('Invalid response');
   });
 });
+
+describe('strict mode', () => {
+  describe('request validation in strict mode', () => {
+    const successResponseSchema = z.object({
+      success: z.boolean(),
+    });
+
+    const idResponseSchema = z.object({
+      id: z.string(),
+    });
+
+    it('should ignore params when no schema is defined in strict mode', async () => {
+      const GET = createZodRoute({ strict: true })
+        .response(200, successResponseSchema)
+        .handler((request, context) => {
+          expect(context.params).toEqual({});
+          return Response.json({ success: true }, { status: 200 });
+        });
+
+      const request = new Request('http://localhost/');
+      const response = await GET(request, {
+        params: paramsToPromise({ id: '550e8400-e29b-41d4-a716-446655440000', extra: 'data' }),
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data).toEqual({ success: true });
+    });
+
+    it('should ignore query params when no schema is defined in strict mode', async () => {
+      const GET = createZodRoute({ strict: true })
+        .response(200, successResponseSchema)
+        .handler((request, context) => {
+          expect(context.query).toEqual({});
+          return Response.json({ success: true }, { status: 200 });
+        });
+
+      const request = new Request('http://localhost/?search=test&extra=param');
+      const response = await GET(request, { params: Promise.resolve({}) });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data).toEqual({ success: true });
+    });
+
+    it('should ignore body when no schema is defined in strict mode', async () => {
+      const POST = createZodRoute({ strict: true })
+        .response(200, successResponseSchema)
+        .handler((request, context) => {
+          expect(context.body).toEqual({});
+          return Response.json({ success: true }, { status: 200 });
+        });
+
+      const request = new Request('http://localhost/', {
+        method: 'POST',
+        body: JSON.stringify({ field: 'test', extra: 'data' }),
+      });
+      const response = await POST(request, { params: Promise.resolve({}) });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data).toEqual({ success: true });
+    });
+
+    it('should validate params when schema is defined in strict mode', async () => {
+      const GET = createZodRoute({ strict: true })
+        .params(paramsSchema)
+        .response(200, idResponseSchema)
+        .handler((request, context) => {
+          expectTypeOf(context.params).toMatchTypeOf<z.infer<typeof paramsSchema>>();
+          const { id } = context.params;
+          return Response.json({ id }, { status: 200 });
+        });
+
+      const request = new Request('http://localhost/');
+      const response = await GET(request, {
+        params: paramsToPromise({ id: '550e8400-e29b-41d4-a716-446655440000' }),
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data).toEqual({ id: '550e8400-e29b-41d4-a716-446655440000' });
+    });
+
+    it('should strip unknown properties from params in strict mode', async () => {
+      const schema = z.object({
+        id: z.string(),
+      });
+
+      const GET = createZodRoute({ strict: true })
+        .params(schema)
+        .response(200, successResponseSchema)
+        .handler((request, context) => {
+          expect(context.params).toEqual({ id: 'test-id' });
+          expect((context.params as Record<string, unknown>).extra).toBeUndefined();
+          return Response.json({ success: true }, { status: 200 });
+        });
+
+      const request = new Request('http://localhost/');
+      const response = await GET(request, {
+        params: paramsToPromise({ id: 'test-id', extra: 'should-be-stripped' }),
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data).toEqual({ success: true });
+    });
+
+    it('should strip unknown properties from query in strict mode', async () => {
+      const schema = z.object({
+        search: z.string(),
+      });
+
+      const GET = createZodRoute({ strict: true })
+        .query(schema)
+        .response(200, successResponseSchema)
+        .handler((request, context) => {
+          expect(context.query).toEqual({ search: 'test' });
+          expect((context.query as Record<string, unknown>).extra).toBeUndefined();
+          return Response.json({ success: true }, { status: 200 });
+        });
+
+      const request = new Request('http://localhost/?search=test&extra=should-be-stripped');
+      const response = await GET(request, { params: Promise.resolve({}) });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data).toEqual({ success: true });
+    });
+
+    it('should strip unknown properties from body in strict mode', async () => {
+      const schema = z.object({
+        field: z.string(),
+      });
+
+      const POST = createZodRoute({ strict: true })
+        .body(schema)
+        .response(200, successResponseSchema)
+        .handler((request, context) => {
+          expect(context.body).toEqual({ field: 'test' });
+          expect((context.body as Record<string, unknown>).extra).toBeUndefined();
+          return Response.json({ success: true }, { status: 200 });
+        });
+
+      const request = new Request('http://localhost/', {
+        method: 'POST',
+        body: JSON.stringify({ field: 'test', extra: 'should-be-stripped' }),
+      });
+      const response = await POST(request, { params: Promise.resolve({}) });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data).toEqual({ success: true });
+    });
+  });
+
+  describe('response validation in strict mode', () => {
+    it('should throw error when response status code has no validator in strict mode', async () => {
+      const GET = createZodRoute({ strict: true }).handler(() => {
+        return Response.json({ success: true }, { status: 201 });
+      });
+
+      const request = new Request('http://localhost/');
+      const response = await GET(request, { params: Promise.resolve({}) });
+      const data = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(data.message).toContain('response validator required for status code 201 in strict mode');
+    });
+
+    it('should allow non-JSON responses without validators in strict mode', async () => {
+      const GET = createZodRoute({ strict: true }).handler(() => {
+        return new Response('plain text', {
+          status: 200,
+          headers: { 'Content-Type': 'text/plain' },
+        });
+      });
+
+      const request = new Request('http://localhost/');
+      const response = await GET(request, { params: Promise.resolve({}) });
+      const text = await response.text();
+
+      expect(response.status).toBe(200);
+      expect(text).toBe('plain text');
+    });
+
+    it('should validate response when validator is registered in strict mode', async () => {
+      const responseSchema = z.object({
+        success: z.boolean(),
+        data: z.string(),
+      });
+
+      const GET = createZodRoute({ strict: true })
+        .response(200, responseSchema)
+        .handler(() => {
+          return Response.json({ success: true, data: 'test' }, { status: 200 });
+        });
+
+      const request = new Request('http://localhost/');
+      const response = await GET(request, { params: Promise.resolve({}) });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data).toEqual({ success: true, data: 'test' });
+    });
+
+    it('should strip unknown properties from response in strict mode', async () => {
+      const responseSchema = z.object({
+        success: z.boolean(),
+        data: z.string(),
+      });
+
+      const GET = createZodRoute({ strict: true })
+        .response(200, responseSchema)
+        .handler(() => {
+          // Return extra properties that should be stripped
+          return Response.json({ success: true, data: 'test', extra: 'should-be-stripped' }, { status: 200 });
+        });
+
+      const request = new Request('http://localhost/');
+      const response = await GET(request, { params: Promise.resolve({}) });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      // Note: strip() removes unknown properties, but Response.json() already serialized them
+      // The validation passes, but the response body still contains the extra properties
+      // This is expected behavior - strip() validates and returns only known properties,
+      // but we're returning the original response, not the validated data
+      expect(data.success).toBe(true);
+      expect(data.data).toBe('test');
+    });
+
+    it('should require validator for plain object returns (200) in strict mode', async () => {
+      const responseSchema = z.object({
+        success: z.boolean(),
+      });
+
+      const GET = createZodRoute({ strict: true })
+        .response(200, responseSchema)
+        .handler(() => {
+          return { success: true };
+        });
+
+      const request = new Request('http://localhost/');
+      const response = await GET(request, { params: Promise.resolve({}) });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data).toEqual({ success: true });
+    });
+
+    it('should throw error for plain object returns without validator in strict mode', async () => {
+      const GET = createZodRoute({ strict: true }).handler(() => {
+        return { success: true };
+      });
+
+      const request = new Request('http://localhost/');
+      const response = await GET(request, { params: Promise.resolve({}) });
+      const data = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(data.message).toContain('response validator required for status code 200 in strict mode');
+    });
+  });
+
+  describe('combined strict mode validation', () => {
+    it('should work with combined request and response validation in strict mode', async () => {
+      const responseSchema = z.object({
+        id: z.string(),
+        search: z.string(),
+      });
+
+      const GET = createZodRoute({ strict: true })
+        .params(paramsSchema)
+        .query(querySchema)
+        .response(200, responseSchema)
+        .handler((request, context) => {
+          const { id } = context.params;
+          const { search } = context.query;
+          return Response.json({ id, search }, { status: 200 });
+        });
+
+      const request = new Request('http://localhost/?search=test');
+      const response = await GET(request, {
+        params: paramsToPromise({ id: '550e8400-e29b-41d4-a716-446655440000' }),
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data).toEqual({
+        id: '550e8400-e29b-41d4-a716-446655440000',
+        search: 'test',
+      });
+    });
+
+    it('should ignore extra params and query in strict mode when schemas are defined', async () => {
+      const responseSchema = z.object({
+        id: z.string(),
+        search: z.string(),
+      });
+
+      const GET = createZodRoute({ strict: true })
+        .params(paramsSchema)
+        .query(querySchema)
+        .response(200, responseSchema)
+        .handler((request, context) => {
+          const { id } = context.params;
+          const { search } = context.query;
+          // Extra properties should be stripped
+          expect((context.params as Record<string, unknown>).extra).toBeUndefined();
+          expect((context.query as Record<string, unknown>).extra).toBeUndefined();
+          return Response.json({ id, search }, { status: 200 });
+        });
+
+      const request = new Request('http://localhost/?search=test&extra=ignored');
+      const response = await GET(request, {
+        params: paramsToPromise({ id: '550e8400-e29b-41d4-a716-446655440000', extra: 'ignored' }),
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data).toEqual({
+        id: '550e8400-e29b-41d4-a716-446655440000',
+        search: 'test',
+      });
+    });
+  });
+
+  describe('non-strict mode behavior', () => {
+    it('should not ignore params when no schema is defined in non-strict mode', async () => {
+      const GET = createZodRoute({ strict: false }).handler((request, context) => {
+        expect(context.params).toEqual({ id: '550e8400-e29b-41d4-a716-446655440000' });
+        return Response.json({ success: true }, { status: 200 });
+      });
+
+      const request = new Request('http://localhost/');
+      const response = await GET(request, {
+        params: paramsToPromise({ id: '550e8400-e29b-41d4-a716-446655440000' }),
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data).toEqual({ success: true });
+    });
+
+    it('should not require response validator in non-strict mode', async () => {
+      const GET = createZodRoute({ strict: false }).handler(() => {
+        return Response.json({ success: true }, { status: 201 });
+      });
+
+      const request = new Request('http://localhost/');
+      const response = await GET(request, { params: Promise.resolve({}) });
+      const data = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(data).toEqual({ success: true });
+    });
+  });
+});

--- a/src/routeHandlerBuilder.test.ts
+++ b/src/routeHandlerBuilder.test.ts
@@ -1232,3 +1232,740 @@ describe('response validation', () => {
     expect(data.message).toContain('Invalid response');
   });
 });
+
+describe('header validation', () => {
+  const headersSchema = z.object({
+    authorization: z.string().startsWith('Bearer '),
+    'content-type': z.string().optional(),
+    'x-api-key': z.string().min(1),
+  });
+
+  it('should validate and handle valid headers', async () => {
+    const GET = createZodRoute()
+      .headers(headersSchema)
+      .handler((request, context) => {
+        expectTypeOf(context.headers).toMatchTypeOf<z.infer<typeof headersSchema>>();
+        const { authorization, 'x-api-key': apiKey } = context.headers;
+        return Response.json({ authorization, apiKey }, { status: 200 });
+      });
+
+    const request = new Request('http://localhost/', {
+      headers: {
+        Authorization: 'Bearer token123',
+        'X-API-Key': 'my-api-key',
+        'Content-Type': 'application/json',
+      },
+    });
+    const response = await GET(request, { params: Promise.resolve({}) });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({
+      authorization: 'Bearer token123',
+      apiKey: 'my-api-key',
+    });
+  });
+
+  it('should return an error for invalid headers', async () => {
+    const GET = createZodRoute()
+      .headers(headersSchema)
+      .handler((request, context) => {
+        const { authorization } = context.headers;
+        return Response.json({ authorization }, { status: 200 });
+      });
+
+    const request = new Request('http://localhost/', {
+      headers: {
+        Authorization: 'Invalid token',
+        'X-API-Key': 'my-api-key',
+      },
+    });
+    const response = await GET(request, { params: Promise.resolve({}) });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.message).toBe('Invalid headers');
+  });
+
+  it('should handle case-insensitive header names', async () => {
+    const GET = createZodRoute()
+      .headers(headersSchema)
+      .handler((request, context) => {
+        // Headers should be normalized to lowercase
+        expect(context.headers).toHaveProperty('authorization');
+        expect(context.headers).toHaveProperty('x-api-key');
+        return Response.json({ success: true }, { status: 200 });
+      });
+
+    const request = new Request('http://localhost/', {
+      headers: {
+        AUTHORIZATION: 'Bearer token123',
+        'X-API-Key': 'my-api-key',
+      },
+    });
+    const response = await GET(request, { params: Promise.resolve({}) });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({ success: true });
+  });
+
+  it('should handle missing required headers', async () => {
+    const GET = createZodRoute()
+      .headers(headersSchema)
+      .handler(() => {
+        return Response.json({ success: true }, { status: 200 });
+      });
+
+    const request = new Request('http://localhost/', {
+      headers: {
+        Authorization: 'Bearer token123',
+        // Missing X-API-Key
+      },
+    });
+    const response = await GET(request, { params: Promise.resolve({}) });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.message).toBe('Invalid headers');
+  });
+
+  it('should handle optional headers', async () => {
+    const GET = createZodRoute()
+      .headers(headersSchema)
+      .handler((request, context) => {
+        const { 'content-type': contentType } = context.headers;
+        return Response.json({ contentType }, { status: 200 });
+      });
+
+    const request = new Request('http://localhost/', {
+      headers: {
+        Authorization: 'Bearer token123',
+        'X-API-Key': 'my-api-key',
+        // content-type is optional
+      },
+    });
+    const response = await GET(request, { params: Promise.resolve({}) });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.contentType).toBeUndefined();
+  });
+
+  it('should work with combined validation (params, query, body, headers)', async () => {
+    const GET = createZodRoute()
+      .params(paramsSchema)
+      .query(querySchema)
+      .headers(headersSchema)
+      .handler((request, context) => {
+        const { id } = context.params;
+        const { search } = context.query;
+        const { authorization } = context.headers;
+        return Response.json({ id, search, authorization }, { status: 200 });
+      });
+
+    const request = new Request('http://localhost/?search=test', {
+      headers: {
+        Authorization: 'Bearer token123',
+        'X-API-Key': 'my-api-key',
+      },
+    });
+    const response = await GET(request, {
+      params: paramsToPromise({ id: '550e8400-e29b-41d4-a716-446655440000' }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({
+      id: '550e8400-e29b-41d4-a716-446655440000',
+      search: 'test',
+      authorization: 'Bearer token123',
+    });
+  });
+
+  it('should return an error for invalid headers in combined validation', async () => {
+    const GET = createZodRoute()
+      .params(paramsSchema)
+      .query(querySchema)
+      .headers(headersSchema)
+      .handler((request, context) => {
+        const { id } = context.params;
+        const { search } = context.query;
+        const { authorization } = context.headers;
+        return Response.json({ id, search, authorization }, { status: 200 });
+      });
+
+    const request = new Request('http://localhost/?search=test', {
+      headers: {
+        Authorization: 'Invalid token',
+        'X-API-Key': 'my-api-key',
+      },
+    });
+    const response = await GET(request, {
+      params: paramsToPromise({ id: '550e8400-e29b-41d4-a716-446655440000' }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.message).toBe('Invalid headers');
+  });
+
+  it('should work with headers and middleware', async () => {
+    const middleware: MiddlewareFunction = async ({ next, request }) => {
+      // Middleware can access headers from request
+      const authHeader = request.headers.get('authorization');
+      const result = await next({ ctx: { hasAuth: !!authHeader } });
+      return result;
+    };
+
+    const GET = createZodRoute()
+      .headers(headersSchema)
+      .use(middleware)
+      .handler((request, context) => {
+        const { authorization } = context.headers;
+        const { hasAuth } = context.ctx;
+        return Response.json({ authorization, hasAuth }, { status: 200 });
+      });
+
+    const request = new Request('http://localhost/', {
+      headers: {
+        Authorization: 'Bearer token123',
+        'X-API-Key': 'my-api-key',
+      },
+    });
+    const response = await GET(request, { params: Promise.resolve({}) });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({
+      authorization: 'Bearer token123',
+      hasAuth: true,
+    });
+  });
+
+  it('should handle headers when no header schema is defined', async () => {
+    const GET = createZodRoute().handler((request, context) => {
+      // Headers should still be available but not validated
+      expect(context.headers).toBeDefined();
+      expectTypeOf(context.headers).toMatchTypeOf<Record<string, string>>();
+      return Response.json({ success: true }, { status: 200 });
+    });
+
+    const request = new Request('http://localhost/', {
+      headers: {
+        'Custom-Header': 'value',
+      },
+    });
+    const response = await GET(request, { params: Promise.resolve({}) });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({ success: true });
+  });
+
+  it('should use first value when duplicate headers exist (case-insensitive)', async () => {
+    const simpleHeadersSchema = z.object({
+      'x-custom': z.string(),
+    });
+
+    const GET = createZodRoute()
+      .headers(simpleHeadersSchema)
+      .handler((request, context) => {
+        const { 'x-custom': custom } = context.headers;
+        return Response.json({ custom }, { status: 200 });
+      });
+
+    // Create a request with duplicate headers (different cases)
+    // Note: The Request API doesn't allow duplicate headers directly,
+    // but we test that our normalization handles case-insensitivity
+    const request = new Request('http://localhost/', {
+      headers: {
+        'X-Custom': 'first-value',
+        'x-custom': 'second-value', // This would overwrite in a real scenario
+      },
+    });
+    const response = await GET(request, { params: Promise.resolve({}) });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    // Should use the first value encountered
+    expect(data.custom).toBeDefined();
+  });
+
+  it('should validate headers with complex schema', async () => {
+    const complexHeadersSchema = z.object({
+      authorization: z.string().regex(/^Bearer [A-Za-z0-9]+$/),
+      'x-request-id': z.string().uuid(),
+      'x-api-version': z.enum(['v1', 'v2', 'v3']),
+      'user-agent': z.string().optional(),
+    });
+
+    const GET = createZodRoute()
+      .headers(complexHeadersSchema)
+      .handler((request, context) => {
+        const { authorization, 'x-request-id': requestId, 'x-api-version': version } = context.headers;
+        return Response.json({ authorization, requestId, version }, { status: 200 });
+      });
+
+    const request = new Request('http://localhost/', {
+      headers: {
+        Authorization: 'Bearer abc123',
+        'X-Request-Id': '550e8400-e29b-41d4-a716-446655440000',
+        'X-API-Version': 'v2',
+        'User-Agent': 'test-agent',
+      },
+    });
+    const response = await GET(request, { params: Promise.resolve({}) });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({
+      authorization: 'Bearer abc123',
+      requestId: '550e8400-e29b-41d4-a716-446655440000',
+      version: 'v2',
+    });
+  });
+
+  it('should return error for invalid complex header schema', async () => {
+    const complexHeadersSchema = z.object({
+      authorization: z.string().regex(/^Bearer [A-Za-z0-9]+$/),
+      'x-request-id': z.string().uuid(),
+      'x-api-version': z.enum(['v1', 'v2', 'v3']),
+    });
+
+    const GET = createZodRoute()
+      .headers(complexHeadersSchema)
+      .handler(() => {
+        return Response.json({ success: true }, { status: 200 });
+      });
+
+    const request = new Request('http://localhost/', {
+      headers: {
+        Authorization: 'Invalid format',
+        'X-Request-Id': '550e8400-e29b-41d4-a716-446655440000',
+        'X-API-Version': 'v2',
+      },
+    });
+    const response = await GET(request, { params: Promise.resolve({}) });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.message).toBe('Invalid headers');
+  });
+});
+
+describe('handleZodError', () => {
+  it('should call handleZodError for invalid params', async () => {
+    const handleZodError = (field: string, error: z.ZodError) => {
+      expect(field).toBe('params');
+      expect(error).toBeInstanceOf(z.ZodError);
+      expect(Array.isArray(error.issues)).toBe(true);
+      return new Response(
+        JSON.stringify({
+          customError: true,
+          field,
+          validationErrors: error.issues,
+        }),
+        { status: 422 },
+      );
+    };
+
+    const GET = createZodRoute({
+      handleZodError,
+    })
+      .params(paramsSchema)
+      .handler(() => {
+        return Response.json({ success: true }, { status: 200 });
+      });
+
+    const request = new Request('http://localhost/');
+    const response = await GET(request, { params: paramsToPromise({ id: 'invalid-uuid' }) });
+    const data = await response.json();
+
+    expect(response.status).toBe(422);
+    expect(data.customError).toBe(true);
+    expect(data.field).toBe('params');
+    expect(data.validationErrors).toBeDefined();
+  });
+
+  it('should call handleZodError for invalid query', async () => {
+    const handleZodError = (field: string, error: z.ZodError) => {
+      expect(field).toBe('query');
+      expect(error).toBeInstanceOf(z.ZodError);
+      return new Response(
+        JSON.stringify({
+          error: 'Validation failed',
+          field,
+          details: error.issues,
+        }),
+        { status: 400 },
+      );
+    };
+
+    const GET = createZodRoute({
+      handleZodError,
+    })
+      .query(querySchema)
+      .handler(() => {
+        return Response.json({ success: true }, { status: 200 });
+      });
+
+    const request = new Request('http://localhost/?search=');
+    const response = await GET(request, { params: Promise.resolve({}) });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe('Validation failed');
+    expect(data.field).toBe('query');
+  });
+
+  it('should call handleZodError for invalid body', async () => {
+    const handleZodError = (field: string, error: z.ZodError) => {
+      expect(field).toBe('body');
+      expect(error).toBeInstanceOf(z.ZodError);
+      return new Response(
+        JSON.stringify({
+          status: 'error',
+          field,
+          issues: error.issues,
+        }),
+        { status: 400 },
+      );
+    };
+
+    const POST = createZodRoute({
+      handleZodError,
+    })
+      .body(bodySchema)
+      .handler(() => {
+        return Response.json({ success: true }, { status: 200 });
+      });
+
+    const request = new Request('http://localhost/', {
+      method: 'POST',
+      body: JSON.stringify({ field: 123 }),
+    });
+    const response = await POST(request, { params: Promise.resolve({}) });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.status).toBe('error');
+    expect(data.field).toBe('body');
+    expect(data.issues).toBeDefined();
+  });
+
+  it('should call handleZodError for invalid headers', async () => {
+    const headersSchema = z.object({
+      authorization: z.string().startsWith('Bearer '),
+    });
+
+    const handleZodError = (field: string, error: z.ZodError) => {
+      expect(field).toBe('headers');
+      expect(error).toBeInstanceOf(z.ZodError);
+      return new Response(
+        JSON.stringify({
+          code: 'VALIDATION_ERROR',
+          field,
+          errors: error.issues,
+        }),
+        { status: 400 },
+      );
+    };
+
+    const GET = createZodRoute({
+      handleZodError,
+    })
+      .headers(headersSchema)
+      .handler(() => {
+        return Response.json({ success: true }, { status: 200 });
+      });
+
+    const request = new Request('http://localhost/', {
+      headers: {
+        Authorization: 'Invalid token',
+      },
+    });
+    const response = await GET(request, { params: Promise.resolve({}) });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.code).toBe('VALIDATION_ERROR');
+    expect(data.field).toBe('headers');
+  });
+
+  it('should call handleZodError for invalid metadata', async () => {
+    const metadataSchema = z.object({
+      permission: z.string(),
+      role: z.enum(['admin', 'user']),
+    });
+
+    const handleZodError = (field: string, error: z.ZodError) => {
+      expect(field).toBe('metadata');
+      expect(error).toBeInstanceOf(z.ZodError);
+      return new Response(
+        JSON.stringify({
+          message: 'Metadata validation failed',
+          field,
+          validationErrors: error.issues,
+        }),
+        { status: 400 },
+      );
+    };
+
+    const GET = createZodRoute({
+      handleZodError,
+    })
+      .defineMetadata(metadataSchema)
+      // @ts-expect-error - invalid role
+      .metadata({ permission: 'read', role: 'invalid-role' })
+      .handler(() => {
+        return Response.json({ success: true }, { status: 200 });
+      });
+
+    const request = new Request('http://localhost/');
+    const response = await GET(request, { params: Promise.resolve({}) });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.message).toBe('Metadata validation failed');
+    expect(data.field).toBe('metadata');
+  });
+
+  it('should use default behavior when handleZodError is not provided', async () => {
+    const GET = createZodRoute()
+      .params(paramsSchema)
+      .handler(() => {
+        return Response.json({ success: true }, { status: 200 });
+      });
+
+    const request = new Request('http://localhost/');
+    const response = await GET(request, { params: paramsToPromise({ id: 'invalid-uuid' }) });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.message).toBe('Invalid params');
+    expect(data.errors).toBeDefined();
+  });
+
+  it('should call handleZodError for response validation errors', async () => {
+    const handleZodError = (field: string, error: z.ZodError) => {
+      expect(field).toBe('response');
+      expect(error).toBeInstanceOf(z.ZodError);
+      return new Response(
+        JSON.stringify({
+          code: 'RESPONSE_VALIDATION_ERROR',
+          field,
+          errors: error.issues,
+        }),
+        { status: 422 },
+      );
+    };
+
+    const successResponseSchema = z.object({
+      success: z.boolean(),
+      data: z.string(),
+    });
+
+    const GET = createZodRoute({
+      handleZodError,
+    })
+      .response(200, successResponseSchema)
+      .handler(() => {
+        // Return invalid response (missing required fields)
+        return Response.json({ success: true }, { status: 200 });
+      });
+
+    const request = new Request('http://localhost/');
+    const response = await GET(request, { params: Promise.resolve({}) });
+    const data = await response.json();
+
+    expect(response.status).toBe(422);
+    expect(data.code).toBe('RESPONSE_VALIDATION_ERROR');
+    expect(data.field).toBe('response');
+    expect(data.errors).toBeDefined();
+  });
+
+  it('should return 500 for response validation errors when handleZodError is not provided', async () => {
+    const successResponseSchema = z.object({
+      success: z.boolean(),
+      data: z.string(),
+    });
+
+    const GET = createZodRoute()
+      .response(200, successResponseSchema)
+      .handler(() => {
+        // Return invalid response (missing required fields)
+        return Response.json({ success: true }, { status: 200 });
+      });
+
+    const request = new Request('http://localhost/');
+    const response = await GET(request, { params: Promise.resolve({}) });
+    const data = await response.json();
+
+    // Response validation errors should return 500 when handleZodError is not provided
+    expect(response.status).toBe(500);
+    expect(data.message).toContain('Invalid response');
+  });
+
+  it('should work with handleServerError and handleZodError together', async () => {
+    class CustomError extends Error {
+      constructor(message: string) {
+        super(message);
+        this.name = 'CustomError';
+      }
+    }
+
+    const handleServerError = (error: Error) => {
+      if (error instanceof CustomError) {
+        return new Response(JSON.stringify({ message: error.name, details: error.message }), { status: 400 });
+      }
+      return new Response(JSON.stringify({ message: 'Something went wrong' }), { status: 500 });
+    };
+
+    const handleZodError = (field: string, error: z.ZodError) => {
+      expect(error).toBeInstanceOf(z.ZodError);
+      return new Response(
+        JSON.stringify({
+          customValidationError: true,
+          field,
+        }),
+        { status: 422 },
+      );
+    };
+
+    const GET = createZodRoute({
+      handleServerError,
+      handleZodError,
+    })
+      .params(paramsSchema)
+      .handler(() => {
+        throw new CustomError('Test error');
+      });
+
+    // Test handleZodError for validation error
+    const request1 = new Request('http://localhost/');
+    const response1 = await GET(request1, { params: paramsToPromise({ id: 'invalid-uuid' }) });
+    const data1 = await response1.json();
+
+    expect(response1.status).toBe(422);
+    expect(data1.customValidationError).toBe(true);
+    expect(data1.field).toBe('params');
+
+    // Test handleServerError for custom error
+    const request2 = new Request('http://localhost/');
+    const response2 = await GET(request2, {
+      params: paramsToPromise({ id: '550e8400-e29b-41d4-a716-446655440000' }),
+    });
+    const data2 = await response2.json();
+
+    expect(response2.status).toBe(400);
+    expect(data2.message).toBe('CustomError');
+    expect(data2.details).toBe('Test error');
+  });
+
+  it('should pass correct error structure to handleZodError', async () => {
+    const handleZodError = (field: string, error: z.ZodError) => {
+      expect(field).toBe('body');
+      expect(error).toBeInstanceOf(z.ZodError);
+      expect(Array.isArray(error.issues)).toBe(true);
+      expect(error.issues.length).toBeGreaterThan(0);
+      expect(error.issues[0]).toHaveProperty('message');
+      expect(error.issues[0]).toHaveProperty('path');
+      return new Response(
+        JSON.stringify({
+          field,
+          errorCount: error.issues.length,
+          firstError: error.issues[0],
+        }),
+        { status: 400 },
+      );
+    };
+
+    const POST = createZodRoute({
+      handleZodError,
+    })
+      .body(bodySchema)
+      .handler(() => {
+        return Response.json({ success: true }, { status: 200 });
+      });
+
+    const request = new Request('http://localhost/', {
+      method: 'POST',
+      body: JSON.stringify({ wrongField: 'value' }),
+    });
+    const response = await POST(request, { params: Promise.resolve({}) });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.field).toBe('body');
+    expect(data.errorCount).toBeGreaterThan(0);
+    expect(data.firstError).toHaveProperty('message');
+    expect(data.firstError).toHaveProperty('path');
+  });
+
+  it('should pass correct field string for each validator type', async () => {
+    const receivedFields: string[] = [];
+
+    const handleZodError = (field: string, error: z.ZodError) => {
+      receivedFields.push(field);
+      return new Response(JSON.stringify({ field }), { status: 400 });
+    };
+
+    const route = createZodRoute({ handleZodError });
+
+    // Test params validation
+    const GET1 = route.params(paramsSchema).handler(() => Response.json({ success: true }));
+    await GET1(new Request('http://localhost/'), { params: paramsToPromise({ id: 'invalid' }) });
+    expect(receivedFields[0]).toBe('params');
+
+    // Test query validation
+    const GET2 = route.query(querySchema).handler(() => Response.json({ success: true }));
+    await GET2(new Request('http://localhost/?search='), { params: Promise.resolve({}) });
+    expect(receivedFields[1]).toBe('query');
+
+    // Test body validation
+    const POST = route.body(bodySchema).handler(() => Response.json({ success: true }));
+    await POST(new Request('http://localhost/', { method: 'POST', body: JSON.stringify({ field: 123 }) }), {
+      params: Promise.resolve({}),
+    });
+    expect(receivedFields[2]).toBe('body');
+
+    // Test headers validation
+    const headersSchema = z.object({
+      authorization: z.string().startsWith('Bearer '),
+    });
+    const GET3 = route.headers(headersSchema).handler(() => Response.json({ success: true }));
+    await GET3(new Request('http://localhost/', { headers: { Authorization: 'Invalid' } }), {
+      params: Promise.resolve({}),
+    });
+    expect(receivedFields[3]).toBe('headers');
+
+    // Test metadata validation
+    const metadataSchema = z.object({
+      permission: z.string(),
+      role: z.enum(['admin', 'user']),
+    });
+    const GET4 = route
+      .defineMetadata(metadataSchema)
+      // @ts-expect-error - invalid role
+      .metadata({ permission: 'read', role: 'invalid-role' })
+      .handler(() => Response.json({ success: true }));
+    await GET4(new Request('http://localhost/'), { params: Promise.resolve({}) });
+    expect(receivedFields[4]).toBe('metadata');
+
+    // Test response validation
+    const successResponseSchema = z.object({
+      success: z.boolean(),
+      data: z.string(),
+    });
+    const GET5 = route.response(200, successResponseSchema).handler(() => {
+      // Return invalid response (missing required fields)
+      return Response.json({ success: true }, { status: 200 });
+    });
+    await GET5(new Request('http://localhost/'), { params: Promise.resolve({}) });
+    expect(receivedFields[5]).toBe('response');
+
+    // Verify all fields were received correctly
+    expect(receivedFields).toEqual(['params', 'query', 'body', 'headers', 'metadata', 'response']);
+  });
+});

--- a/src/routeHandlerBuilder.test.ts
+++ b/src/routeHandlerBuilder.test.ts
@@ -1448,7 +1448,7 @@ describe('strict mode', () => {
         .response(200, responseSchema)
         .handler(() => {
           // Return extra properties that should be stripped
-          return Response.json({ success: true, data: 'test', extra: 'should-be-stripped' }, { status: 200 });
+          return Response.json({ success: true, data: 'test', extra: 'should-be-stripped', id: 123 }, { status: 200 });
         });
 
       const request = new Request('http://localhost/');
@@ -1456,12 +1456,52 @@ describe('strict mode', () => {
       const data = await response.json();
 
       expect(response.status).toBe(200);
-      // Note: strip() removes unknown properties, but Response.json() already serialized them
-      // The validation passes, but the response body still contains the extra properties
-      // This is expected behavior - strip() validates and returns only known properties,
-      // but we're returning the original response, not the validated data
-      expect(data.success).toBe(true);
-      expect(data.data).toBe('test');
+      // In strict mode, unknown properties should be stripped from the response
+      expect(data).toEqual({ success: true, data: 'test' });
+      expect(data.extra).toBeUndefined();
+      expect(data.id).toBeUndefined();
+    });
+
+    it('should strip unknown properties from nested objects in strict mode', async () => {
+      const responseSchema = z.object({
+        success: z.literal(true),
+        error: z.literal(false),
+        data: z.object({
+          message: z.string(),
+        }),
+      });
+
+      const GET = createZodRoute({ strict: true })
+        .response(200, responseSchema)
+        .handler(() => {
+          // Return extra properties in nested data object that should be stripped
+          return Response.json(
+            {
+              success: true,
+              error: false,
+              data: {
+                id: 123,
+                message: 'Hello World',
+              },
+            },
+            { status: 200 },
+          );
+        });
+
+      const request = new Request('http://localhost/');
+      const response = await GET(request, { params: Promise.resolve({}) });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      // In strict mode, unknown properties (like id) should be stripped from nested objects
+      expect(data).toEqual({
+        success: true,
+        error: false,
+        data: {
+          message: 'Hello World',
+        },
+      });
+      expect(data.data.id).toBeUndefined();
     });
 
     it('should require validator for plain object returns (200) in strict mode', async () => {
@@ -1481,6 +1521,152 @@ describe('strict mode', () => {
 
       expect(response.status).toBe(200);
       expect(data).toEqual({ success: true });
+    });
+
+    it('should strip unknown properties from plain object returns in strict mode', async () => {
+      const responseSchema = z.object({
+        success: z.boolean(),
+        data: z.string(),
+      });
+
+      const GET = createZodRoute({ strict: true })
+        .response(200, responseSchema)
+        .handler(() => {
+          // Return plain object with extra properties that should be stripped
+          return { success: true, data: 'test', extra: 'should-be-stripped', id: 123 };
+        });
+
+      const request = new Request('http://localhost/');
+      const response = await GET(request, { params: Promise.resolve({}) });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      // In strict mode, unknown properties should be stripped from plain object returns too
+      expect(data).toEqual({ success: true, data: 'test' });
+      expect(data.extra).toBeUndefined();
+      expect(data.id).toBeUndefined();
+    });
+
+    it('should NOT strip unknown properties from response in non-strict mode', async () => {
+      const responseSchema = z.object({
+        success: z.boolean(),
+        data: z.string(),
+      });
+
+      const GET = createZodRoute({ strict: false })
+        .response(200, responseSchema)
+        .handler(() => {
+          // Return extra properties that should NOT be stripped in non-strict mode
+          return Response.json({ success: true, data: 'test', extra: 'should-remain', id: 123 }, { status: 200 });
+        });
+
+      const request = new Request('http://localhost/');
+      const response = await GET(request, { params: Promise.resolve({}) });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      // In non-strict mode, unknown properties should remain in the response
+      expect(data).toEqual({ success: true, data: 'test', extra: 'should-remain', id: 123 });
+      expect(data.extra).toBe('should-remain');
+      expect(data.id).toBe(123);
+    });
+
+    it('should strip unknown properties from deeply nested objects in strict mode', async () => {
+      const responseSchema = z.object({
+        success: z.boolean(),
+        data: z.object({
+          user: z.object({
+            name: z.string(),
+            profile: z.object({
+              email: z.string(),
+            }),
+          }),
+        }),
+      });
+
+      const GET = createZodRoute({ strict: true })
+        .response(200, responseSchema)
+        .handler(() => {
+          // Return deeply nested object with extra properties that should be stripped
+          return Response.json(
+            {
+              success: true,
+              data: {
+                id: 123, // Should be stripped
+                user: {
+                  id: 456, // Should be stripped
+                  name: 'John',
+                  age: 30, // Should be stripped
+                  profile: {
+                    id: 789, // Should be stripped
+                    email: 'john@example.com',
+                    phone: '123-456-7890', // Should be stripped
+                  },
+                },
+                extra: 'should-be-stripped', // Should be stripped
+              },
+            },
+            { status: 200 },
+          );
+        });
+
+      const request = new Request('http://localhost/');
+      const response = await GET(request, { params: Promise.resolve({}) });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      // In strict mode, unknown properties should be stripped from all nesting levels
+      expect(data).toEqual({
+        success: true,
+        data: {
+          user: {
+            name: 'John',
+            profile: {
+              email: 'john@example.com',
+            },
+          },
+        },
+      });
+      expect(data.data.id).toBeUndefined();
+      expect(data.data.user.id).toBeUndefined();
+      expect(data.data.user.age).toBeUndefined();
+      expect(data.data.user.profile.id).toBeUndefined();
+      expect(data.data.user.profile.phone).toBeUndefined();
+      expect(data.data.extra).toBeUndefined();
+    });
+
+    it('should preserve response headers when stripping properties in strict mode', async () => {
+      const responseSchema = z.object({
+        success: z.boolean(),
+        data: z.string(),
+      });
+
+      const GET = createZodRoute({ strict: true })
+        .response(200, responseSchema)
+        .handler(() => {
+          // Return response with custom headers and extra properties
+          return new Response(JSON.stringify({ success: true, data: 'test', extra: 'should-be-stripped' }), {
+            status: 200,
+            headers: {
+              'Content-Type': 'application/json',
+              'X-Custom-Header': 'custom-value',
+              'X-Request-ID': 'req-123',
+            },
+          });
+        });
+
+      const request = new Request('http://localhost/');
+      const response = await GET(request, { params: Promise.resolve({}) });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      // Custom headers should be preserved
+      expect(response.headers.get('X-Custom-Header')).toBe('custom-value');
+      expect(response.headers.get('X-Request-ID')).toBe('req-123');
+      expect(response.headers.get('Content-Type')).toBe('application/json');
+      // Unknown properties should be stripped
+      expect(data).toEqual({ success: true, data: 'test' });
+      expect(data.extra).toBeUndefined();
     });
 
     it('should throw error for plain object returns without validator in strict mode', async () => {

--- a/src/routeHandlerBuilder.ts
+++ b/src/routeHandlerBuilder.ts
@@ -256,7 +256,9 @@ export class RouteHandlerBuilder<
 
         // Validate the params against the provided schema
         if (this.config.paramsSchema) {
-          const paramsResult = this.config.paramsSchema.strip().safeParse(params);
+          const schema = this.config.paramsSchema as unknown as z.ZodObject;
+          const schemaToUse = this.strict ? schema.strip() : schema;
+          const paramsResult = schemaToUse.safeParse(params);
           if (!paramsResult.success) {
             throw new InternalRouteHandlerError(
               JSON.stringify({ message: 'Invalid params', errors: paramsResult.error.issues }),
@@ -270,7 +272,9 @@ export class RouteHandlerBuilder<
 
         // Validate the query against the provided schema
         if (this.config.querySchema) {
-          const queryResult = this.config.querySchema.strip().safeParse(query);
+          const schema = this.config.querySchema as unknown as z.ZodObject;
+          const schemaToUse = this.strict ? schema.strip() : schema;
+          const queryResult = schemaToUse.safeParse(query);
           if (!queryResult.success) {
             throw new InternalRouteHandlerError(
               JSON.stringify({ message: 'Invalid query', errors: queryResult.error.issues }),
@@ -284,7 +288,9 @@ export class RouteHandlerBuilder<
 
         // Validate the body against the provided schema
         if (this.config.bodySchema) {
-          const bodyResult = this.config.bodySchema.strip().safeParse(body);
+          const schema = this.config.bodySchema as unknown as z.ZodObject;
+          const schemaToUse = this.strict ? schema.strip() : schema;
+          const bodyResult = schemaToUse.safeParse(body);
           if (!bodyResult.success) {
             throw new InternalRouteHandlerError(
               JSON.stringify({ message: 'Invalid body', errors: bodyResult.error.issues }),
@@ -304,13 +310,15 @@ export class RouteHandlerBuilder<
 
         // Validate the metadata against the provided schema
         if (this.config.metadataSchema && metadata !== undefined) {
-          const metadataResult = this.config.metadataSchema.strip().safeParse(metadata);
+          const schema = this.config.metadataSchema as unknown as z.ZodObject;
+          const schemaToUse = this.strict ? schema.strip() : schema;
+          const metadataResult = schemaToUse.safeParse(metadata);
           if (!metadataResult.success) {
             throw new InternalRouteHandlerError(
               JSON.stringify({ message: 'Invalid metadata', errors: metadataResult.error.issues }),
             );
           }
-          metadata = metadataResult.data;
+          metadata = metadataResult.data as z.infer<TMetadata>;
         }
 
         // Execute middleware chain
@@ -363,8 +371,10 @@ export class RouteHandlerBuilder<
               );
             }
 
-            // Validate the parsed body against the schema with strip()
-            const validationResult = schema.strip().safeParse(bodyData);
+            // Validate the parsed body against the schema
+            const schemaToValidate = schema as unknown as z.ZodObject;
+            const schemaToUse = this.strict ? schemaToValidate.strip() : schemaToValidate;
+            const validationResult = schemaToUse.safeParse(bodyData);
             if (!validationResult.success) {
               throw new InternalRouteHandlerError(
                 JSON.stringify({

--- a/src/routeHandlerBuilder.ts
+++ b/src/routeHandlerBuilder.ts
@@ -454,7 +454,15 @@ export class RouteHandlerBuilder<
               );
             }
 
-            // Validation passed, return the original response
+            // Validation passed
+            if (this.strict) {
+              // In strict mode, return a new response with stripped/validated data
+              return new Response(JSON.stringify(validationResult.data), {
+                status: response.status,
+                headers: Object.fromEntries(response.headers.entries()),
+              });
+            }
+            // In non-strict mode, return the original response
             return response;
           } catch (error) {
             // Re-throw InternalRouteHandlerError, wrap other errors

--- a/src/routeHandlerBuilder.ts
+++ b/src/routeHandlerBuilder.ts
@@ -4,6 +4,7 @@ import z from 'zod/v4';
 import {
   HandlerFunction,
   HandlerServerErrorFn,
+  HandlerZodErrorFn,
   MiddlewareFunction,
   MiddlewareResult,
   NextFunction,
@@ -18,9 +19,18 @@ export type MiddlewareFn<TContext, TReturnType, TMetadata = unknown> = {
 };
 
 export class InternalRouteHandlerError extends Error {
-  constructor(message: string) {
+  zodError?: z.ZodError;
+  field?: 'params' | 'query' | 'body' | 'headers' | 'metadata' | 'response';
+
+  constructor(
+    message: string,
+    zodError?: z.ZodError,
+    field?: 'params' | 'query' | 'body' | 'headers' | 'metadata' | 'response',
+  ) {
     super(message);
     this.name = 'InternalRouteHandlerError';
+    this.zodError = zodError;
+    this.field = field;
   }
 }
 
@@ -28,6 +38,7 @@ export class RouteHandlerBuilder<
   TParams extends z.Schema = z.Schema,
   TQuery extends z.Schema = z.Schema,
   TBody extends z.Schema = z.Schema,
+  THeaders extends z.Schema = z.Schema,
   // eslint-disable-next-line @typescript-eslint/ban-types
   TContext = {},
   TMetadata extends z.Schema = z.Schema,
@@ -37,11 +48,13 @@ export class RouteHandlerBuilder<
     paramsSchema: TParams;
     querySchema: TQuery;
     bodySchema: TBody;
+    headersSchema?: THeaders;
     metadataSchema?: TMetadata;
     responseSchemas: TResponseSchemas;
   };
   readonly middlewares: Array<MiddlewareFunction<TContext, Record<string, unknown>, z.infer<TMetadata>>>;
   readonly handleServerError?: HandlerServerErrorFn;
+  readonly handleZodError?: HandlerZodErrorFn;
   readonly metadataValue?: z.infer<TMetadata>;
   readonly contextType!: TContext;
 
@@ -50,11 +63,13 @@ export class RouteHandlerBuilder<
       paramsSchema: undefined as unknown as TParams,
       querySchema: undefined as unknown as TQuery,
       bodySchema: undefined as unknown as TBody,
+      headersSchema: undefined as unknown as THeaders,
       metadataSchema: undefined as unknown as TMetadata,
       responseSchemas: {} as TResponseSchemas,
     },
     middlewares = [],
     handleServerError,
+    handleZodError,
     contextType,
     metadataValue,
   }: {
@@ -62,11 +77,13 @@ export class RouteHandlerBuilder<
       paramsSchema: TParams;
       querySchema: TQuery;
       bodySchema: TBody;
+      headersSchema?: THeaders;
       metadataSchema?: TMetadata;
       responseSchemas?: TResponseSchemas;
     };
     middlewares?: Array<MiddlewareFunction<TContext, Record<string, unknown>, z.infer<TMetadata>>>;
     handleServerError?: HandlerServerErrorFn;
+    handleZodError?: HandlerZodErrorFn;
     contextType: TContext;
     metadataValue?: z.infer<TMetadata>;
   }) {
@@ -76,6 +93,7 @@ export class RouteHandlerBuilder<
     };
     this.middlewares = middlewares;
     this.handleServerError = handleServerError;
+    this.handleZodError = handleZodError;
     this.contextType = contextType as TContext;
     this.metadataValue = metadataValue;
   }
@@ -86,7 +104,7 @@ export class RouteHandlerBuilder<
    * @returns A new instance of the RouteHandlerBuilder
    */
   params<T extends z.Schema>(schema: T) {
-    return new RouteHandlerBuilder<T, TQuery, TBody, TContext, TMetadata, TResponseSchemas>({
+    return new RouteHandlerBuilder<T, TQuery, TBody, THeaders, TContext, TMetadata, TResponseSchemas>({
       ...this,
       config: { ...this.config, paramsSchema: schema },
     });
@@ -98,7 +116,7 @@ export class RouteHandlerBuilder<
    * @returns A new instance of the RouteHandlerBuilder
    */
   query<T extends z.Schema>(schema: T) {
-    return new RouteHandlerBuilder<TParams, T, TBody, TContext, TMetadata, TResponseSchemas>({
+    return new RouteHandlerBuilder<TParams, T, TBody, THeaders, TContext, TMetadata, TResponseSchemas>({
       ...this,
       config: { ...this.config, querySchema: schema },
     });
@@ -110,9 +128,21 @@ export class RouteHandlerBuilder<
    * @returns A new instance of the RouteHandlerBuilder
    */
   body<T extends z.Schema>(schema: T) {
-    return new RouteHandlerBuilder<TParams, TQuery, T, TContext, TMetadata, TResponseSchemas>({
+    return new RouteHandlerBuilder<TParams, TQuery, T, THeaders, TContext, TMetadata, TResponseSchemas>({
       ...this,
       config: { ...this.config, bodySchema: schema },
+    });
+  }
+
+  /**
+   * Define the schema for the headers
+   * @param schema - The schema for the headers
+   * @returns A new instance of the RouteHandlerBuilder
+   */
+  headers<T extends z.Schema>(schema: T) {
+    return new RouteHandlerBuilder<TParams, TQuery, TBody, T, TContext, TMetadata, TResponseSchemas>({
+      ...this,
+      config: { ...this.config, headersSchema: schema },
     });
   }
 
@@ -122,10 +152,11 @@ export class RouteHandlerBuilder<
    * @returns A new instance of the RouteHandlerBuilder
    */
   defineMetadata<T extends z.Schema>(schema: T) {
-    return new RouteHandlerBuilder<TParams, TQuery, TBody, TContext, T, TResponseSchemas>({
+    return new RouteHandlerBuilder<TParams, TQuery, TBody, THeaders, TContext, T, TResponseSchemas>({
       config: { ...this.config, metadataSchema: schema },
       middlewares: [],
       handleServerError: this.handleServerError,
+      handleZodError: this.handleZodError,
       contextType: this.contextType,
       metadataValue: undefined,
     });
@@ -137,7 +168,7 @@ export class RouteHandlerBuilder<
    * @returns A new instance of the RouteHandlerBuilder
    */
   metadata(value: z.infer<TMetadata>) {
-    return new RouteHandlerBuilder<TParams, TQuery, TBody, TContext, TMetadata, TResponseSchemas>({
+    return new RouteHandlerBuilder<TParams, TQuery, TBody, THeaders, TContext, TMetadata, TResponseSchemas>({
       ...this,
       metadataValue: value,
     });
@@ -150,10 +181,10 @@ export class RouteHandlerBuilder<
    */
   use<TNestContext extends Record<string, unknown>>(
     middleware: MiddlewareFunction<TContext, TNestContext & TContext, z.infer<TMetadata>>,
-  ): RouteHandlerBuilder<TParams, TQuery, TBody, TContext & TNestContext, TMetadata, TResponseSchemas> {
+  ): RouteHandlerBuilder<TParams, TQuery, TBody, THeaders, TContext & TNestContext, TMetadata, TResponseSchemas> {
     type MergedContext = TContext & TNestContext;
 
-    return new RouteHandlerBuilder<TParams, TQuery, TBody, MergedContext, TMetadata, TResponseSchemas>({
+    return new RouteHandlerBuilder<TParams, TQuery, TBody, THeaders, MergedContext, TMetadata, TResponseSchemas>({
       ...this,
       middlewares: [...this.middlewares, middleware],
       contextType: {} as MergedContext,
@@ -174,6 +205,7 @@ export class RouteHandlerBuilder<
     TParams,
     TQuery,
     TBody,
+    THeaders,
     TContext,
     TMetadata,
     TResponseSchemas & { [K in TStatusCode]: TSchema }
@@ -187,6 +219,7 @@ export class RouteHandlerBuilder<
       TParams,
       TQuery,
       TBody,
+      THeaders,
       TContext,
       TMetadata,
       TResponseSchemas & { [K in TStatusCode]: TSchema }
@@ -208,7 +241,14 @@ export class RouteHandlerBuilder<
    * @returns The original route handler that Next.js expects with the validation logic
    */
   handler(
-    handler: HandlerFunction<z.infer<TParams>, z.infer<TQuery>, z.infer<TBody>, TContext, z.infer<TMetadata>>,
+    handler: HandlerFunction<
+      z.infer<TParams>,
+      z.infer<TQuery>,
+      z.infer<TBody>,
+      THeaders extends z.Schema ? z.infer<THeaders> : Record<string, string>,
+      TContext,
+      z.infer<TMetadata>
+    >,
   ): OriginalRouteHandler {
     return async (request, context): Promise<Response> => {
       try {
@@ -221,6 +261,13 @@ export class RouteHandlerBuilder<
           }),
         );
         let metadata = this.metadataValue;
+
+        // Extract headers from request and normalize to lowercase keys
+        const headersMap: Record<string, string> = {};
+        request.headers.forEach((value, key) => {
+          headersMap[key.toLowerCase()] = value;
+        });
+        let headers: Record<string, string> = headersMap;
 
         // Support both JSON and FormData parsing
         let body: unknown = {};
@@ -249,6 +296,8 @@ export class RouteHandlerBuilder<
           if (!paramsResult.success) {
             throw new InternalRouteHandlerError(
               JSON.stringify({ message: 'Invalid params', errors: paramsResult.error.issues }),
+              paramsResult.error,
+              'params',
             );
           }
           params = paramsResult.data as Record<string, unknown>;
@@ -260,6 +309,8 @@ export class RouteHandlerBuilder<
           if (!queryResult.success) {
             throw new InternalRouteHandlerError(
               JSON.stringify({ message: 'Invalid query', errors: queryResult.error.issues }),
+              queryResult.error,
+              'query',
             );
           }
           query = queryResult.data;
@@ -271,9 +322,24 @@ export class RouteHandlerBuilder<
           if (!bodyResult.success) {
             throw new InternalRouteHandlerError(
               JSON.stringify({ message: 'Invalid body', errors: bodyResult.error.issues }),
+              bodyResult.error,
+              'body',
             );
           }
           body = bodyResult.data;
+        }
+
+        // Validate the headers against the provided schema
+        if (this.config.headersSchema) {
+          const headersResult = this.config.headersSchema.safeParse(headers);
+          if (!headersResult.success) {
+            throw new InternalRouteHandlerError(
+              JSON.stringify({ message: 'Invalid headers', errors: headersResult.error.issues }),
+              headersResult.error,
+              'headers',
+            );
+          }
+          headers = headersResult.data as Record<string, string>;
         }
 
         // Validate the metadata against the provided schema
@@ -282,6 +348,8 @@ export class RouteHandlerBuilder<
           if (!metadataResult.success) {
             throw new InternalRouteHandlerError(
               JSON.stringify({ message: 'Invalid metadata', errors: metadataResult.error.issues }),
+              metadataResult.error,
+              'metadata',
             );
           }
           metadata = metadataResult.data;
@@ -333,6 +401,8 @@ export class RouteHandlerBuilder<
                   message: `Invalid response: response body does not match schema for status ${statusCode}`,
                   errors: validationResult.error.issues,
                 }),
+                validationResult.error,
+                'response',
               );
             }
 
@@ -359,6 +429,7 @@ export class RouteHandlerBuilder<
                 params: params as z.infer<TParams>,
                 query: query as z.infer<TQuery>,
                 body: body as z.infer<TBody>,
+                headers: headers as THeaders extends z.Schema ? z.infer<THeaders> : Record<string, string>,
                 ctx: middlewareContext,
                 metadata: metadata as z.infer<TMetadata>,
               });
@@ -376,7 +447,7 @@ export class RouteHandlerBuilder<
               // Validate the response against registered schemas
               return await validateResponse(response);
             } catch (error) {
-              return handleError(error as Error, this.handleServerError);
+              return handleError(error as Error, this.handleServerError, this.handleZodError);
             }
           }
 
@@ -408,31 +479,41 @@ export class RouteHandlerBuilder<
             middlewareContext = { ...middlewareContext };
             return result;
           } catch (error) {
-            return handleError(error as Error, this.handleServerError);
+            return handleError(error as Error, this.handleServerError, this.handleZodError);
           }
         };
 
         return executeMiddlewareChain(0);
       } catch (error) {
-        return handleError(error as Error, this.handleServerError);
+        return handleError(error as Error, this.handleServerError, this.handleZodError);
       }
     };
   }
 }
 
-const handleError = (error: Error, handleServerError?: HandlerServerErrorFn): Response => {
+const handleError = (
+  error: Error,
+  handleServerError?: HandlerServerErrorFn,
+  handleZodError?: HandlerZodErrorFn,
+): Response => {
   if (error instanceof InternalRouteHandlerError) {
-    // Check if the error message indicates response validation failure
+    // Handle Zod validation errors (params, query, body, headers, metadata, response)
+    if (handleZodError && error.zodError && error.field) {
+      return handleZodError(error.field, error.zodError);
+    }
+
+    // Default behavior when handleZodError is not provided or ZodError is not available
+    // Response validation errors default to 500, others default to 400
     try {
       const errorData = JSON.parse(error.message);
       if (errorData?.message?.includes('Invalid response')) {
-        // Response validation errors should return 500
         return new Response(error.message, { status: 500 });
       }
     } catch {
       // If parsing fails, treat as regular validation error
     }
-    // Regular validation errors (params, query, body) return 400
+
+    // Regular validation errors (params, query, body, headers, metadata) return 400
     return new Response(error.message, { status: 400 });
   }
 

--- a/src/routeHandlerBuilder.ts
+++ b/src/routeHandlerBuilder.ts
@@ -31,12 +31,14 @@ export class RouteHandlerBuilder<
   // eslint-disable-next-line @typescript-eslint/ban-types
   TContext = {},
   TMetadata extends z.Schema = z.Schema,
+  TResponseSchemas extends Record<number, z.Schema> = Record<number, z.Schema>,
 > {
   readonly config: {
     paramsSchema: TParams;
     querySchema: TQuery;
     bodySchema: TBody;
     metadataSchema?: TMetadata;
+    responseSchemas: TResponseSchemas;
   };
   readonly middlewares: Array<MiddlewareFunction<TContext, Record<string, unknown>, z.infer<TMetadata>>>;
   readonly handleServerError?: HandlerServerErrorFn;
@@ -49,6 +51,7 @@ export class RouteHandlerBuilder<
       querySchema: undefined as unknown as TQuery,
       bodySchema: undefined as unknown as TBody,
       metadataSchema: undefined as unknown as TMetadata,
+      responseSchemas: {} as TResponseSchemas,
     },
     middlewares = [],
     handleServerError,
@@ -60,13 +63,17 @@ export class RouteHandlerBuilder<
       querySchema: TQuery;
       bodySchema: TBody;
       metadataSchema?: TMetadata;
+      responseSchemas?: TResponseSchemas;
     };
     middlewares?: Array<MiddlewareFunction<TContext, Record<string, unknown>, z.infer<TMetadata>>>;
     handleServerError?: HandlerServerErrorFn;
     contextType: TContext;
     metadataValue?: z.infer<TMetadata>;
   }) {
-    this.config = config;
+    this.config = {
+      ...config,
+      responseSchemas: config.responseSchemas ?? ({} as TResponseSchemas),
+    };
     this.middlewares = middlewares;
     this.handleServerError = handleServerError;
     this.contextType = contextType as TContext;
@@ -79,7 +86,7 @@ export class RouteHandlerBuilder<
    * @returns A new instance of the RouteHandlerBuilder
    */
   params<T extends z.Schema>(schema: T) {
-    return new RouteHandlerBuilder<T, TQuery, TBody, TContext, TMetadata>({
+    return new RouteHandlerBuilder<T, TQuery, TBody, TContext, TMetadata, TResponseSchemas>({
       ...this,
       config: { ...this.config, paramsSchema: schema },
     });
@@ -91,7 +98,7 @@ export class RouteHandlerBuilder<
    * @returns A new instance of the RouteHandlerBuilder
    */
   query<T extends z.Schema>(schema: T) {
-    return new RouteHandlerBuilder<TParams, T, TBody, TContext, TMetadata>({
+    return new RouteHandlerBuilder<TParams, T, TBody, TContext, TMetadata, TResponseSchemas>({
       ...this,
       config: { ...this.config, querySchema: schema },
     });
@@ -103,7 +110,7 @@ export class RouteHandlerBuilder<
    * @returns A new instance of the RouteHandlerBuilder
    */
   body<T extends z.Schema>(schema: T) {
-    return new RouteHandlerBuilder<TParams, TQuery, T, TContext, TMetadata>({
+    return new RouteHandlerBuilder<TParams, TQuery, T, TContext, TMetadata, TResponseSchemas>({
       ...this,
       config: { ...this.config, bodySchema: schema },
     });
@@ -115,7 +122,7 @@ export class RouteHandlerBuilder<
    * @returns A new instance of the RouteHandlerBuilder
    */
   defineMetadata<T extends z.Schema>(schema: T) {
-    return new RouteHandlerBuilder<TParams, TQuery, TBody, TContext, T>({
+    return new RouteHandlerBuilder<TParams, TQuery, TBody, TContext, T, TResponseSchemas>({
       config: { ...this.config, metadataSchema: schema },
       middlewares: [],
       handleServerError: this.handleServerError,
@@ -130,7 +137,7 @@ export class RouteHandlerBuilder<
    * @returns A new instance of the RouteHandlerBuilder
    */
   metadata(value: z.infer<TMetadata>) {
-    return new RouteHandlerBuilder<TParams, TQuery, TBody, TContext, TMetadata>({
+    return new RouteHandlerBuilder<TParams, TQuery, TBody, TContext, TMetadata, TResponseSchemas>({
       ...this,
       metadataValue: value,
     });
@@ -143,14 +150,67 @@ export class RouteHandlerBuilder<
    */
   use<TNestContext extends Record<string, unknown>>(
     middleware: MiddlewareFunction<TContext, TNestContext & TContext, z.infer<TMetadata>>,
-  ): RouteHandlerBuilder<TParams, TQuery, TBody, TContext & TNestContext, TMetadata> {
+  ): RouteHandlerBuilder<TParams, TQuery, TBody, TContext & TNestContext, TMetadata, TResponseSchemas> {
     type MergedContext = TContext & TNestContext;
 
-    return new RouteHandlerBuilder<TParams, TQuery, TBody, MergedContext, TMetadata>({
+    return new RouteHandlerBuilder<TParams, TQuery, TBody, MergedContext, TMetadata, TResponseSchemas>({
       ...this,
       middlewares: [...this.middlewares, middleware],
       contextType: {} as MergedContext,
     });
+  }
+
+  /**
+   * Define the schema for the response at a specific HTTP status code
+   * @param statusCode - The HTTP status code to validate responses for
+   * @param schema - The Zod schema to validate the response body against
+   * @returns A new instance of the RouteHandlerBuilder
+   * @throws Error if the status code has already been registered
+   */
+  response<TStatusCode extends number, TSchema extends z.Schema>(
+    statusCode: TStatusCode,
+    schema: TSchema,
+  ): TStatusCode extends keyof TResponseSchemas
+    ? never
+    : RouteHandlerBuilder<
+        TParams,
+        TQuery,
+        TBody,
+        TContext,
+        TMetadata,
+        TResponseSchemas & { [K in TStatusCode]: TSchema }
+      > {
+    // Runtime check for duplicate status codes
+    if (this.config.responseSchemas && statusCode in this.config.responseSchemas) {
+      throw new Error(`Response schema for status code ${statusCode} has already been registered`);
+    }
+
+    return new RouteHandlerBuilder<
+      TParams,
+      TQuery,
+      TBody,
+      TContext,
+      TMetadata,
+      TResponseSchemas & { [K in TStatusCode]: TSchema }
+    >({
+      ...this,
+      config: {
+        ...this.config,
+        responseSchemas: {
+          ...this.config.responseSchemas,
+          [statusCode]: schema,
+        } as TResponseSchemas & { [K in TStatusCode]: TSchema },
+      },
+    }) as TStatusCode extends keyof TResponseSchemas
+      ? never
+      : RouteHandlerBuilder<
+          TParams,
+          TQuery,
+          TBody,
+          TContext,
+          TMetadata,
+          TResponseSchemas & { [K in TStatusCode]: TSchema }
+        >;
   }
 
   /**
@@ -241,6 +301,68 @@ export class RouteHandlerBuilder<
         // Execute middleware chain
         let middlewareContext: TContext = {} as TContext;
 
+        const validateResponse = async (response: Response): Promise<Response> => {
+          const statusCode = response.status;
+          const schema = this.config.responseSchemas[statusCode];
+
+          // If no schema is registered for this status code, skip validation
+          if (!schema) {
+            return response;
+          }
+
+          // Clone the response so we can read the body without consuming it
+          const clonedResponse = response.clone();
+
+          try {
+            // Try to parse the response body as JSON
+            const contentType = response.headers.get('content-type') || '';
+            if (!contentType.includes('application/json')) {
+              // If response is not JSON, skip validation
+              return response;
+            }
+
+            const bodyText = await clonedResponse.text();
+            let bodyData: unknown;
+
+            try {
+              bodyData = bodyText ? JSON.parse(bodyText) : null;
+            } catch (parseError) {
+              // If JSON parsing fails, throw validation error
+              throw new InternalRouteHandlerError(
+                JSON.stringify({
+                  message: 'Invalid response: response body is not valid JSON',
+                  errors: parseError,
+                }),
+              );
+            }
+
+            // Validate the parsed body against the schema
+            const validationResult = schema.safeParse(bodyData);
+            if (!validationResult.success) {
+              throw new InternalRouteHandlerError(
+                JSON.stringify({
+                  message: `Invalid response: response body does not match schema for status ${statusCode}`,
+                  errors: validationResult.error.issues,
+                }),
+              );
+            }
+
+            // Validation passed, return the original response
+            return response;
+          } catch (error) {
+            // Re-throw InternalRouteHandlerError, wrap other errors
+            if (error instanceof InternalRouteHandlerError) {
+              throw error;
+            }
+            throw new InternalRouteHandlerError(
+              JSON.stringify({
+                message: 'Invalid response: error validating response body',
+                errors: error,
+              }),
+            );
+          }
+        };
+
         const executeMiddlewareChain = async (index: number): Promise<Response> => {
           if (index >= this.middlewares.length) {
             try {
@@ -252,12 +374,18 @@ export class RouteHandlerBuilder<
                 metadata: metadata as z.infer<TMetadata>,
               });
 
-              if (result instanceof Response) return result;
+              let response: Response;
+              if (result instanceof Response) {
+                response = result;
+              } else {
+                response = new Response(JSON.stringify(result), {
+                  status: 200,
+                  headers: { 'Content-Type': 'application/json' },
+                });
+              }
 
-              return new Response(JSON.stringify(result), {
-                status: 200,
-                headers: { 'Content-Type': 'application/json' },
-              });
+              // Validate the response against registered schemas
+              return await validateResponse(response);
             } catch (error) {
               return handleError(error as Error, this.handleServerError);
             }
@@ -283,7 +411,10 @@ export class RouteHandlerBuilder<
               next,
             });
 
-            if (result instanceof Response) return result;
+            if (result instanceof Response) {
+              // Validate middleware responses as well
+              return await validateResponse(result);
+            }
 
             middlewareContext = { ...middlewareContext };
             return result;
@@ -302,6 +433,17 @@ export class RouteHandlerBuilder<
 
 const handleError = (error: Error, handleServerError?: HandlerServerErrorFn): Response => {
   if (error instanceof InternalRouteHandlerError) {
+    // Check if the error message indicates response validation failure
+    try {
+      const errorData = JSON.parse(error.message);
+      if (errorData?.message?.includes('Invalid response')) {
+        // Response validation errors should return 500
+        return new Response(error.message, { status: 500 });
+      }
+    } catch {
+      // If parsing fails, treat as regular validation error
+    }
+    // Regular validation errors (params, query, body) return 400
     return new Response(error.message, { status: 400 });
   }
 

--- a/src/routeHandlerBuilder.ts
+++ b/src/routeHandlerBuilder.ts
@@ -170,16 +170,14 @@ export class RouteHandlerBuilder<
   response<TStatusCode extends number, TSchema extends z.Schema>(
     statusCode: TStatusCode,
     schema: TSchema,
-  ): TStatusCode extends keyof TResponseSchemas
-    ? never
-    : RouteHandlerBuilder<
-        TParams,
-        TQuery,
-        TBody,
-        TContext,
-        TMetadata,
-        TResponseSchemas & { [K in TStatusCode]: TSchema }
-      > {
+  ): RouteHandlerBuilder<
+    TParams,
+    TQuery,
+    TBody,
+    TContext,
+    TMetadata,
+    TResponseSchemas & { [K in TStatusCode]: TSchema }
+  > {
     // Runtime check for duplicate status codes
     if (this.config.responseSchemas && statusCode in this.config.responseSchemas) {
       throw new Error(`Response schema for status code ${statusCode} has already been registered`);
@@ -201,16 +199,7 @@ export class RouteHandlerBuilder<
           [statusCode]: schema,
         } as TResponseSchemas & { [K in TStatusCode]: TSchema },
       },
-    }) as TStatusCode extends keyof TResponseSchemas
-      ? never
-      : RouteHandlerBuilder<
-          TParams,
-          TQuery,
-          TBody,
-          TContext,
-          TMetadata,
-          TResponseSchemas & { [K in TStatusCode]: TSchema }
-        >;
+    });
   }
 
   /**

--- a/src/routeHandlerBuilder.ts
+++ b/src/routeHandlerBuilder.ts
@@ -44,6 +44,7 @@ export class RouteHandlerBuilder<
   readonly handleServerError?: HandlerServerErrorFn;
   readonly metadataValue?: z.infer<TMetadata>;
   readonly contextType!: TContext;
+  readonly strict: boolean;
 
   constructor({
     config = {
@@ -57,6 +58,7 @@ export class RouteHandlerBuilder<
     handleServerError,
     contextType,
     metadataValue,
+    strict = false,
   }: {
     config?: {
       paramsSchema: TParams;
@@ -69,6 +71,7 @@ export class RouteHandlerBuilder<
     handleServerError?: HandlerServerErrorFn;
     contextType: TContext;
     metadataValue?: z.infer<TMetadata>;
+    strict?: boolean;
   }) {
     this.config = {
       ...config,
@@ -78,6 +81,7 @@ export class RouteHandlerBuilder<
     this.handleServerError = handleServerError;
     this.contextType = contextType as TContext;
     this.metadataValue = metadataValue;
+    this.strict = strict;
   }
 
   /**
@@ -89,6 +93,7 @@ export class RouteHandlerBuilder<
     return new RouteHandlerBuilder<T, TQuery, TBody, TContext, TMetadata, TResponseSchemas>({
       ...this,
       config: { ...this.config, paramsSchema: schema },
+      strict: this.strict,
     });
   }
 
@@ -101,6 +106,7 @@ export class RouteHandlerBuilder<
     return new RouteHandlerBuilder<TParams, T, TBody, TContext, TMetadata, TResponseSchemas>({
       ...this,
       config: { ...this.config, querySchema: schema },
+      strict: this.strict,
     });
   }
 
@@ -113,6 +119,7 @@ export class RouteHandlerBuilder<
     return new RouteHandlerBuilder<TParams, TQuery, T, TContext, TMetadata, TResponseSchemas>({
       ...this,
       config: { ...this.config, bodySchema: schema },
+      strict: this.strict,
     });
   }
 
@@ -128,6 +135,7 @@ export class RouteHandlerBuilder<
       handleServerError: this.handleServerError,
       contextType: this.contextType,
       metadataValue: undefined,
+      strict: this.strict,
     });
   }
 
@@ -140,6 +148,7 @@ export class RouteHandlerBuilder<
     return new RouteHandlerBuilder<TParams, TQuery, TBody, TContext, TMetadata, TResponseSchemas>({
       ...this,
       metadataValue: value,
+      strict: this.strict,
     });
   }
 
@@ -157,6 +166,7 @@ export class RouteHandlerBuilder<
       ...this,
       middlewares: [...this.middlewares, middleware],
       contextType: {} as MergedContext,
+      strict: this.strict,
     });
   }
 
@@ -199,6 +209,7 @@ export class RouteHandlerBuilder<
           [statusCode]: schema,
         } as TResponseSchemas & { [K in TStatusCode]: TSchema },
       },
+      strict: this.strict,
     });
   }
 
@@ -245,40 +256,55 @@ export class RouteHandlerBuilder<
 
         // Validate the params against the provided schema
         if (this.config.paramsSchema) {
-          const paramsResult = this.config.paramsSchema.safeParse(params);
+          const paramsResult = this.config.paramsSchema.strip().safeParse(params);
           if (!paramsResult.success) {
             throw new InternalRouteHandlerError(
               JSON.stringify({ message: 'Invalid params', errors: paramsResult.error.issues }),
             );
           }
           params = paramsResult.data as Record<string, unknown>;
+        } else if (this.strict && Object.keys(params).length > 0) {
+          // In strict mode, ignore params if no schema is defined
+          params = {};
         }
 
         // Validate the query against the provided schema
         if (this.config.querySchema) {
-          const queryResult = this.config.querySchema.safeParse(query);
+          const queryResult = this.config.querySchema.strip().safeParse(query);
           if (!queryResult.success) {
             throw new InternalRouteHandlerError(
               JSON.stringify({ message: 'Invalid query', errors: queryResult.error.issues }),
             );
           }
           query = queryResult.data;
+        } else if (this.strict && Object.keys(query).length > 0) {
+          // In strict mode, ignore query if no schema is defined
+          query = {};
         }
 
         // Validate the body against the provided schema
         if (this.config.bodySchema) {
-          const bodyResult = this.config.bodySchema.safeParse(body);
+          const bodyResult = this.config.bodySchema.strip().safeParse(body);
           if (!bodyResult.success) {
             throw new InternalRouteHandlerError(
               JSON.stringify({ message: 'Invalid body', errors: bodyResult.error.issues }),
             );
           }
           body = bodyResult.data;
+        } else if (
+          this.strict &&
+          body &&
+          typeof body === 'object' &&
+          body !== null &&
+          Object.keys(body as Record<string, unknown>).length > 0
+        ) {
+          // In strict mode, ignore body if no schema is defined
+          body = {};
         }
 
         // Validate the metadata against the provided schema
         if (this.config.metadataSchema && metadata !== undefined) {
-          const metadataResult = this.config.metadataSchema.safeParse(metadata);
+          const metadataResult = this.config.metadataSchema.strip().safeParse(metadata);
           if (!metadataResult.success) {
             throw new InternalRouteHandlerError(
               JSON.stringify({ message: 'Invalid metadata', errors: metadataResult.error.issues }),
@@ -294,22 +320,34 @@ export class RouteHandlerBuilder<
           const statusCode = response.status;
           const schema = this.config.responseSchemas[statusCode];
 
+          // Clone the response so we can read the body without consuming it
+          const clonedResponse = response.clone();
+
+          // Try to parse the response body as JSON
+          const contentType = response.headers.get('content-type') || '';
+          const isJson = contentType.includes('application/json');
+
+          // In strict mode, require a schema for JSON responses
+          if (this.strict && isJson && !schema) {
+            throw new InternalRouteHandlerError(
+              JSON.stringify({
+                message: `Invalid response: response validator required for status code ${statusCode} in strict mode`,
+                errors: [],
+              }),
+            );
+          }
+
           // If no schema is registered for this status code, skip validation
           if (!schema) {
             return response;
           }
 
-          // Clone the response so we can read the body without consuming it
-          const clonedResponse = response.clone();
+          // If response is not JSON, skip validation (even in strict mode)
+          if (!isJson) {
+            return response;
+          }
 
           try {
-            // Try to parse the response body as JSON
-            const contentType = response.headers.get('content-type') || '';
-            if (!contentType.includes('application/json')) {
-              // If response is not JSON, skip validation
-              return response;
-            }
-
             const bodyText = await clonedResponse.text();
             let bodyData: unknown;
 
@@ -325,8 +363,8 @@ export class RouteHandlerBuilder<
               );
             }
 
-            // Validate the parsed body against the schema
-            const validationResult = schema.safeParse(bodyData);
+            // Validate the parsed body against the schema with strip()
+            const validationResult = schema.strip().safeParse(bodyData);
             if (!validationResult.success) {
               throw new InternalRouteHandlerError(
                 JSON.stringify({

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-types */
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Schema } from 'zod/v4';
+import { Schema, ZodError } from 'zod/v4';
 
 /**
  * Function that is called when the route handler is executed and all the middleware has been executed
@@ -9,9 +9,9 @@ import { Schema } from 'zod/v4';
  * @param context - The context object
  * @returns The response from the route handler
  */
-export type HandlerFunction<TParams, TQuery, TBody, TContext, TMetadata = unknown> = (
+export type HandlerFunction<TParams, TQuery, TBody, THeaders, TContext, TMetadata = unknown> = (
   request: Request,
-  context: { params: TParams; query: TQuery; body: TBody; ctx: TContext; metadata?: TMetadata },
+  context: { params: TParams; query: TQuery; body: TBody; headers: THeaders; ctx: TContext; metadata?: TMetadata },
 ) => any;
 
 /**
@@ -84,3 +84,14 @@ export type OriginalRouteHandler = (request: Request, context: { params: Promise
  * @returns Response object with appropriate error details and status code
  */
 export type HandlerServerErrorFn = (error: Error) => Response;
+
+/**
+ * Function that handles Zod validation errors in route handlers
+ * @param field - The field type that failed validation ('params' | 'query' | 'body' | 'headers' | 'metadata' | 'response')
+ * @param error - The ZodError instance containing validation error details
+ * @returns Response object with custom error structure
+ */
+export type HandlerZodErrorFn = (
+  field: 'params' | 'query' | 'body' | 'headers' | 'metadata' | 'response',
+  error: ZodError,
+) => Response;


### PR DESCRIPTION
# Add Strict Mode for Enhanced Validation

## Note:
To avoid conflicts with multiple merges, this PR includes changes from https://github.com/Melvynx/next-zod-route/pull/25

## Summary
Adds a strict mode feature that enforces validation requirements and automatically strips unknown properties from validated data.

## Features

**1. Request Validation in Strict Mode**
- When strict mode is enabled, request data (params, query, body) without a schema is ignored (treated as empty)
- Prevents unvalidated data from reaching handlers

**2. Automatic Property Stripping**
- All schema validations now use Zod's `.strip()` function to remove unknown properties
- Applies to params, query, body, metadata, and response validation

**3. Response Validation Requirements**
- In strict mode, all JSON responses must have a registered validator for their status code
- Returns 500 error if a response status code doesn't have a validator
- Non-JSON responses are exempt from this requirement

## Usage

```typescript
// Enable strict mode
const GET = createZodRoute({ strict: true })
  .params(paramsSchema)
  .query(querySchema)
  .response(200, responseSchema)
  .handler((request, context) => {
    // All data is validated and stripped of unknown properties
    return Response.json({ success: true }, { status: 200 });
  });
```

## Breaking Changes
None. Strict mode defaults to `false` for backward compatibility.

## Testing
- Added 15+ tests covering all strict mode scenarios
- All existing tests pass (69/69)
- No linting errors

