### PR TITLE
Fixes zod schema parsing errors not being handled by handleServerError

### DIFF
--- a/src/routeHandlerBuilder.ts
+++ b/src/routeHandlerBuilder.ts
@@ -301,12 +301,12 @@ export class RouteHandlerBuilder<
 }
 
 const handleError = (error: Error, handleServerError?: HandlerServerErrorFn): Response => {
-  if (error instanceof InternalRouteHandlerError) {
-    return new Response(error.message, { status: 400 });
-  }
-
   if (handleServerError) {
     return handleServerError(error as Error);
+  }
+
+  if (error instanceof InternalRouteHandlerError) {
+    return new Response(error.message, { status: 400 });
   }
 
   return new Response(JSON.stringify({ message: 'Internal server error' }), { status: 500 });


### PR DESCRIPTION
As the title says:

Fixes zod schema parsing errors not being handled by handleServerError

## Proposed Changes

- Changes handleError function to call .handleServerError before handling instanceof InternalRouteHandlerError as it is was presented in original

Really like this fork, but there was no need to change [original handleError](http://github.com/richardsolomou/next-safe-route/blob/main/src/routeHandlerBuilder.ts#L149)